### PR TITLE
Resync `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     },
     "docs": {
       "name": "@signalium/docs",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.9.2",
@@ -56,7 +56,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-highlight-words": "^0.20.0",
-        "signalium": "0.3.4",
+        "signalium": "0.3.5",
         "simple-functional-loader": "^1.2.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.3.3"
@@ -8368,7 +8368,7 @@
       }
     },
     "packages/signalium": {
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "ISC",
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
When I cloned the repository and ran `npm install`, the
`package-lock.json` file changed; it seems like it has gotten out of
sync.
