### PR TITLE
Fix useFrameworkScope in React integration

### DIFF
--- a/.changeset/rude-ducks-hunt.md
+++ b/.changeset/rude-ducks-hunt.md
@@ -1,0 +1,5 @@
+---
+'signalium': patch
+---
+
+Fix useFrameworkScope integration in React

--- a/packages/signalium/src/internals/derived.ts
+++ b/packages/signalium/src/internals/derived.ts
@@ -3,12 +3,11 @@ import { Tracer, TRACER, TracerMeta } from '../trace.js';
 import { ReactiveValue, Signal, SignalEquals, SignalListener, SignalOptionsWithInit } from '../types.js';
 import { getUnknownSignalFnName } from './utils/debug-name.js';
 import { SignalScope } from './contexts.js';
-import { checkAndRunListeners, getSignal } from './get.js';
-import { Edge, EdgeType, SignalEdge } from './edge.js';
+import { getSignal } from './get.js';
+import { Edge } from './edge.js';
 import { schedulePull, scheduleUnwatch } from './scheduling.js';
 import { hashValue } from './utils/hash.js';
 import { stringifyValue } from './utils/stringify.js';
-import { equalsFrom } from './utils/equals.js';
 
 /**
  * This file contains computed signal base types and struct definitions.

--- a/packages/signalium/src/react/__tests__/contexts.test.tsx
+++ b/packages/signalium/src/react/__tests__/contexts.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { state, reactive, createContext, useContext } from 'signalium';
-import { ContextProvider, setupReact } from '../index.js';
+import { ContextProvider, setupReact, useScope } from '../index.js';
 import React, { useState } from 'react';
 
 setupReact();
@@ -95,5 +95,24 @@ describe('React > contexts', () => {
     override.set('Hi');
 
     await expect.element(getByText('Hi, World')).toBeInTheDocument();
+  });
+
+  test('useScope returns undefined outside of rendering context', async () => {
+    // Direct call outside of rendering should return undefined
+    expect(useScope()).toBeUndefined();
+
+    // Inside a component during rendering, it should return the scope
+    function TestComponent() {
+      const scope = useScope();
+      return <div data-testid="scope">{scope ? 'has-scope' : 'no-scope'}</div>;
+    }
+
+    const { getByTestId } = render(
+      <ContextProvider contexts={[]}>
+        <TestComponent />
+      </ContextProvider>,
+    );
+
+    await expect.element(getByTestId('scope')).toHaveTextContent('has-scope');
   });
 });

--- a/packages/signalium/src/react/context.ts
+++ b/packages/signalium/src/react/context.ts
@@ -1,8 +1,14 @@
 import { createContext, useContext } from 'react';
 import { SignalScope } from '../internals/contexts.js';
+import { isRendering } from './rendering.js';
 
 export const ScopeContext = createContext<SignalScope | undefined>(undefined);
 
 export function useScope() {
+  if (!isRendering()) {
+    return undefined;
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useContext(ScopeContext);
 }

--- a/packages/signalium/src/react/provider.tsx
+++ b/packages/signalium/src/react/provider.tsx
@@ -13,12 +13,6 @@ export function ContextProvider<C extends unknown[]>({
   inherit?: boolean;
   root?: boolean;
 }) {
-  // if (root) {
-  //   useEffect(() => )
-
-  //   return <ScopeContext.Provider value={scope}>{children}</ScopeContext.Provider>;
-  // }
-
   const parentScope = useContext(ScopeContext);
   const scope = new SignalScope(contexts as [ContextImpl<unknown>, unknown][], inherit ? parentScope : undefined);
 

--- a/packages/signalium/src/react/rendering.ts
+++ b/packages/signalium/src/react/rendering.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+
+// This is a private React internal that we need to access to check if we are rendering.
+// There is no other consistent way to check if we are rendering in both development
+// and production, and it doesn't appear that the React team wants to add one. This
+// should be checked on every major React version upgrade.
+const REACT_INTERNALS =
+  (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED ||
+  (React as any).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE ||
+  (React as any).__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+
+const IS_REACT_18 = !!REACT_INTERNALS.ReactCurrentDispatcher;
+const ReactCurrentDispatcher = REACT_INTERNALS.ReactCurrentDispatcher || REACT_INTERNALS;
+
+export function isRendering() {
+  const dispatcher = IS_REACT_18 ? ReactCurrentDispatcher.current : ReactCurrentDispatcher.H;
+
+  return (
+    !!dispatcher &&
+    // dispatcher can be in a state where it's defined, but all hooks are invalid to call.
+    // Only way we can tell is that if they are invalid, they will all be equal to each other
+    // (e.g. because it's the function that throws an error)
+    dispatcher.useState !== dispatcher.useEffect
+  );
+}

--- a/packages/signalium/src/react/signal-value.ts
+++ b/packages/signalium/src/react/signal-value.ts
@@ -1,34 +1,11 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import React, { useCallback, useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import type { DerivedSignal } from '../internals/derived.js';
 import type { StateSignal } from '../internals/state.js';
 import type { ReactiveValue } from '../types.js';
 import { isReactivePromise } from '../internals/utils/type-utils.js';
 import { isReactiveSubscription } from '../internals/async.js';
-
-// This is a private React internal that we need to access to check if we are rendering.
-// There is no other consistent way to check if we are rendering in both development
-// and production, and it doesn't appear that the React team wants to add one. This
-// should be checked on every major React version upgrade.
-const REACT_INTERNALS =
-  (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED ||
-  (React as any).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE ||
-  (React as any).__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
-
-const IS_REACT_18 = !!REACT_INTERNALS.ReactCurrentDispatcher;
-const ReactCurrentDispatcher = REACT_INTERNALS.ReactCurrentDispatcher || REACT_INTERNALS;
-
-function isRendering() {
-  const dispatcher = IS_REACT_18 ? ReactCurrentDispatcher.current : ReactCurrentDispatcher.H;
-
-  return (
-    !!dispatcher &&
-    // dispatcher can be in a state where it's defined, but all hooks are invalid to call.
-    // Only way we can tell is that if they are invalid, they will all be equal to each other
-    // (e.g. because it's the function that throws an error)
-    dispatcher.useState !== dispatcher.useEffect
-  );
-}
+import { isRendering } from './rendering.js';
 
 export function useStateSignal<T>(signal: StateSignal<T>): T {
   if (!isRendering()) {


### PR DESCRIPTION
`useFrameworkScope` needs to guard its usage of `useContext` so it doesn't throw errors when used outside of React