### PR TITLE
Add runReactiveSafe

### DIFF
--- a/.changeset/small-cities-grin.md
+++ b/.changeset/small-cities-grin.md
@@ -1,0 +1,5 @@
+---
+'signalium': minor
+---
+
+Add runReactiveSafe for running reactive functions safely in React apps

--- a/packages/signalium/src/react/index.ts
+++ b/packages/signalium/src/react/index.ts
@@ -2,3 +2,5 @@ export { ContextProvider } from './provider.js';
 export { useScope } from './context.js';
 export { setupReact } from './setup.js';
 export { useStateSignal } from './state.js';
+
+export { runReactiveSafe } from './rendering.js';


### PR DESCRIPTION
Adds the `runReactiveSafe` utility function for accessing reactive functions safely outside of React's render cycle. This is more of a metaprogramming issue, but essentially, imagine a utility function that you have that uses a reactive function. If that utility function is called while rendering, and it's called _conditionally_, it will throw an error since it implicitly uses hooks to call the function. 

This provides a way to read the function safely from elsewhere in the application by disabling the React integration entirely.