### PR TITLE
Fix setRootContexts memory leak

### DIFF
--- a/.changeset/weak-rules-dig.md
+++ b/.changeset/weak-rules-dig.md
@@ -1,0 +1,5 @@
+---
+'signalium': patch
+---
+
+Make setRootContexts reuse existing scope so we don't leak memory

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     },
     "docs": {
       "name": "@signalium/docs",
-      "version": "0.0.12",
+      "version": "0.0.16",
       "license": "ISC",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.9.2",
@@ -56,7 +56,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-highlight-words": "^0.20.0",
-        "signalium": "1.0.2",
+        "signalium": "1.2.1",
         "simple-functional-loader": "^1.2.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.3.3"
@@ -7895,7 +7895,7 @@
       }
     },
     "packages/signalium": {
-      "version": "1.0.2",
+      "version": "1.2.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.6",

--- a/packages/signalium/src/__tests__/gc.test.ts
+++ b/packages/signalium/src/__tests__/gc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { reactive, createContext, withContexts, watcher, state } from '../index.js';
-import { SignalScope, ROOT_SCOPE, forceGc, clearRootScope } from '../internals/contexts.js';
+import { SignalScope, ROOT_SCOPE, forceGc, clearRootContexts } from '../internals/contexts.js';
 import { nextTick, sleep } from './utils/async.js';
 
 // Helper to access private properties for testing
@@ -14,7 +14,7 @@ const getGCCandidates = (scope: SignalScope) => {
 
 describe('Garbage Collection', () => {
   beforeEach(() => {
-    clearRootScope();
+    clearRootContexts();
   });
 
   it('should automatically garbage collect unwatched signals', async () => {

--- a/packages/signalium/src/index.ts
+++ b/packages/signalium/src/index.ts
@@ -11,6 +11,7 @@ export {
   useContext,
   withContexts,
   setRootContexts,
+  clearRootContexts,
   SignalScope,
   CONTEXT_KEY,
 } from './internals/contexts.js';

--- a/packages/signalium/src/internals/contexts.ts
+++ b/packages/signalium/src/internals/contexts.ts
@@ -36,19 +36,23 @@ export const createContext = <T>(initialValue: T, description?: string): Context
 
 export class SignalScope {
   constructor(contexts: [ContextImpl<unknown>, unknown][], parent?: SignalScope) {
-    this.parentScope = parent;
     this.contexts = Object.create(parent?.contexts || null);
 
-    for (const [context, value] of contexts) {
-      this.contexts[context._key] = value;
-    }
+    this.setContexts(contexts);
   }
 
-  private parentScope?: SignalScope = undefined;
   private contexts: Record<symbol, unknown>;
   private children = new Map<number, SignalScope>();
   private signals = new Map<number, DerivedSignal<any, any>>();
   private gcCandidates = new Set<DerivedSignal<any, any>>();
+
+  setContexts(contexts: [ContextImpl<unknown>, unknown][]) {
+    for (const [context, value] of contexts) {
+      this.contexts[context._key] = value;
+    }
+
+    this.signals.clear();
+  }
 
   getChild(contexts: [ContextImpl<unknown>, unknown][]) {
     const key = hashValue(contexts);
@@ -119,10 +123,10 @@ export class SignalScope {
 export let ROOT_SCOPE = new SignalScope([]);
 
 export function setRootContexts<C extends unknown[], U>(contexts: [...ContextPair<C>]): void {
-  ROOT_SCOPE = new SignalScope(contexts as [ContextImpl<unknown>, unknown][], ROOT_SCOPE);
+  ROOT_SCOPE.setContexts(contexts as [ContextImpl<unknown>, unknown][]);
 }
 
-export const clearRootScope = () => {
+export const clearRootContexts = () => {
   ROOT_SCOPE = new SignalScope([]);
 };
 


### PR DESCRIPTION
Fixes a potential memory leak (and ultimately just inefficient usage) by always reusing the same root scope when setting root contexts