### PR TITLE
Add reactiveMethod

### DIFF
--- a/.changeset/dark-symbols-smile.md
+++ b/.changeset/dark-symbols-smile.md
@@ -1,0 +1,5 @@
+---
+'signalium': major
+---
+
+Add reactiveMethods

--- a/packages/signalium/src/__tests__/callback.test.ts
+++ b/packages/signalium/src/__tests__/callback.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { createContext, getContext, withContexts, signal } from '../index.js';
+import { context, getContext, withContexts, signal } from '../index.js';
 import { reactive } from './utils/instrumented-hooks.js';
 import { nextTick } from './utils/async.js';
 
 describe('callback + reactive scope/identity', () => {
   test('reactive called in a callback defined in a reactive function has the correct scope (via contexts)', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const inner = reactive(() => {
       return getContext(ctx);
@@ -31,7 +31,7 @@ describe('callback + reactive scope/identity', () => {
   });
 
   test('reactive called via nested callbacks maintains correct scope across multiple levels', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const inner = reactive(() => getContext(ctx));
 
@@ -127,7 +127,7 @@ describe('callback + reactive scope/identity', () => {
   });
 
   test('async callbacks maintain their captured scope across await boundaries', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const makeAsyncCb = reactive(() => {
       return async () => {

--- a/packages/signalium/src/__tests__/context.test.ts
+++ b/packages/signalium/src/__tests__/context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { createContext, getContext, withContexts, signal, setRootContexts } from '../index.js';
+import { context, getContext, withContexts, signal, setGlobalContexts } from '../index.js';
 import { permute } from './utils/permute.js';
 import { nextTick } from './utils/async.js';
 import { reactive } from './utils/instrumented-hooks.js';
@@ -7,23 +7,23 @@ import { reactive } from './utils/instrumented-hooks.js';
 describe('contexts', () => {
   test('throws when useContext is used outside of a signal', () => {
     expect(() => {
-      getContext(createContext('test'));
+      getContext(context('test'));
     }).toThrow('getContext must be used within a reactive function');
   });
 
-  test('setRootContexts sets contexts at the root level', () => {
+  test('setGlobalContexts sets contexts at the root level', () => {
     const value = signal('Hello');
-    const context = createContext(value);
+    const ctx = context(value);
     const override = signal('Hey');
 
     // Create a reactive function that uses the context
-    const derived = reactive(() => `${getContext(context).value}, World`);
+    const derived = reactive(() => `${getContext(ctx).value}, World`);
 
     // Initially should use default value
     expect(derived()).toBe('Hello, World');
 
     // Set root contexts
-    setRootContexts([[context, override]]);
+    setGlobalContexts([[ctx, override]]);
 
     // Should now use the override value
     expect(derived()).toBe('Hey, World');
@@ -33,11 +33,11 @@ describe('contexts', () => {
     expect(derived()).toBe('Hi, World');
   });
 
-  test('setRootContexts with multiple contexts', () => {
+  test('setGlobalContexts with multiple contexts', () => {
     const value1 = signal('Hello');
     const value2 = signal('World');
-    const context1 = createContext(value1);
-    const context2 = createContext(value2);
+    const context1 = context(value1);
+    const context2 = context(value2);
     const override1 = signal('Hey');
     const override2 = signal('There');
 
@@ -47,7 +47,7 @@ describe('contexts', () => {
     expect(derived()).toBe('Hello, World');
 
     // Set multiple root contexts
-    setRootContexts([
+    setGlobalContexts([
       [context1, override1],
       [context2, override2],
     ]);
@@ -68,13 +68,13 @@ describe('contexts', () => {
   test('withContexts inherits from root scope', () => {
     const defaultValue1 = signal('default1');
     const defaultValue2 = signal('default2');
-    const ctx1 = createContext(defaultValue1);
-    const ctx2 = createContext(defaultValue2);
+    const ctx1 = context(defaultValue1);
+    const ctx2 = context(defaultValue2);
     const rootOverride1 = signal('root1');
     const rootOverride2 = signal('root2');
 
     // Set root contexts
-    setRootContexts([
+    setGlobalContexts([
       [ctx1, rootOverride1],
       [ctx2, rootOverride2],
     ]);
@@ -114,7 +114,7 @@ describe('contexts', () => {
   });
 
   test('async computed maintains context ownership across await boundaries', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const inner = reactive(async () => {
       await Promise.resolve();
@@ -149,7 +149,7 @@ describe('contexts', () => {
   });
 
   test('async task maintains context ownership across await boundaries', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const task = reactive(async () => {
       await Promise.resolve();
@@ -158,7 +158,7 @@ describe('contexts', () => {
 
   permute(1, create => {
     test('computed signals are cached per context scope', async () => {
-      const ctx = createContext('default');
+      const ctx = context('default');
       const value = signal(0);
 
       const computed = create(
@@ -194,124 +194,11 @@ describe('contexts', () => {
 
       expect(computed).toHaveSignalValue('default0').toMatchSnapshot();
     });
-
-    // test.skip('computed forks when accessing forked context after being shared', async () => {
-    //   const ctx = createContext('default');
-    //   const value = signal(0);
-
-    //   const computed = create(() => {
-    //     // Initially only depends on value, not context
-    //     const v = value.get();
-    //     if (v > 0) {
-    //       // After value changes, depends on context
-    //       return useContext(ctx);
-    //     }
-    //     return 'default';
-    //   });
-
-    //   // Initially computed is shared between scopes since it doesn't use context
-    //   expect(computed).withContexts([ctx, 'scope1']).toHaveValueAndCounts('default', { compute: 1 });
-    //   expect(computed).withContexts([ctx, 'scope2']).toHaveValueAndCounts('default', { compute: 1 });
-
-    //   // Change value to make computed use context
-    //   value.set(1);
-
-    //   await nextTick();
-
-    //   // Now computed should fork and use the different context values
-    //   expect(computed).withContexts([ctx, 'scope1']).toHaveValueAndCounts('scope1', { compute: 3 });
-    //   expect(computed).withContexts([ctx, 'scope2']).toHaveValueAndCounts('scope2', { compute: 3 });
-
-    //   // Ensure that computed is cached correctly
-    //   expect(computed).withContexts([ctx, 'scope1']).toHaveValueAndCounts('scope1', { compute: 3 });
-    //   expect(computed).withContexts([ctx, 'scope2']).toHaveValueAndCounts('scope2', { compute: 3 });
-    // });
-
-    // test.skip('computed forks correctly regardless of access order', () => {
-    //   const ctx = createContext('default');
-    //   const value = signal(0);
-
-    //   const computed = create(() => {
-    //     // Initially only depends on value, not context
-    //     const v = value.get();
-    //     if (v > 0) {
-    //       // After value changes, depends on context
-    //       return useContext(ctx);
-    //     }
-    //     return v;
-    //   });
-
-    //   // Create two scopes with different context values, but access in reverse order
-    //   expect(computed).withContexts([ctx, 'scope1']).toHaveValueAndCounts(0, { compute: 1 });
-
-    //   expect(computed).withContexts([ctx, 'scope2']).toHaveValueAndCounts(0, { compute: 1 }); // Still shared since no context dependency
-
-    //   // Change value to make computed use context
-    //   value.set(1);
-
-    //   // Now computed should fork and use the different context values
-    //   // Access in reverse order compared to first test
-    //   expect(computed).withContexts([ctx, 'scope2']).toHaveValueAndCounts('scope2', { compute: 2 });
-
-    //   expect(computed).withContexts([ctx, 'scope1']).toHaveValueAndCounts('scope1', { compute: 3 });
-
-    //   // Ensure that computed is cached correctly
-    //   expect(computed).withContexts([ctx, 'scope1']).toHaveValueAndCounts('scope1', { compute: 3 });
-
-    //   expect(computed).withContexts([ctx, 'scope2']).toHaveValueAndCounts('scope2', { compute: 3 });
-    // });
-
-    // test.skip('computed ownership transfers correctly between parent and child scopes', () => {
-    //   const ctx = createContext('default');
-    //   const value = signal(0);
-
-    //   const computed = create(() => {
-    //     // Initially only depends on value, not context
-    //     const v = value.get();
-    //     if (v > 0) {
-    //       // After value changes, depends on context
-    //       return useContext(ctx) + v;
-    //     }
-    //     return v;
-    //   });
-
-    //   // Initially access in parent scope
-    //   expect(computed).toHaveValueAndCounts(0, { compute: 1 });
-
-    //   // Child scope reuses original computed instance since no context dependency
-    //   expect(computed).withContexts([ctx, 'child']).toHaveValueAndCounts(0, { compute: 1 });
-
-    //   // Change value to make computed use context
-    //   value.set(1);
-
-    //   // Child scope takes ownership of parent instance
-    //   expect(computed).withContexts([ctx, 'child']).toHaveValueAndCounts('child1', { compute: 2 });
-
-    //   // Parent scope gets its own computed instance
-    //   expect(computed).toHaveValueAndCounts('default1', { compute: 3 });
-
-    //   // Third scope gets its own computed instance
-    //   expect(computed).withContexts([ctx, 'third']).toHaveValueAndCounts('third1', { compute: 4 });
-
-    //   // Ensure computeds are cached correctly
-    //   expect(computed).withContexts([ctx, 'child']).toHaveValueAndCounts('child1', { compute: 4 });
-
-    //   expect(computed).toHaveValueAndCounts('default1', { compute: 4 });
-
-    //   // Verify all scopes maintain their separate computeds
-    //   value.set(2);
-
-    //   expect(computed).withContexts([ctx, 'child']).toHaveValueAndCounts('child2', { compute: 5 });
-
-    //   expect(computed).toHaveValueAndCounts('default2', { compute: 6 });
-
-    //   expect(computed).withContexts([ctx, 'third']).toHaveValueAndCounts('third2', { compute: 7 });
-    // });
   });
 
   permute(2, (create1, create2) => {
     test('contexts are properly scoped', async () => {
-      const ctx = createContext('default');
+      const ctx = context('default');
 
       const computed1 = create1(() => {
         return getContext(ctx);
@@ -337,41 +224,9 @@ describe('contexts', () => {
       // expect(computed1).toHaveSignalValue('default').toMatchSnapshot();
     });
 
-    // test.skip('context dependencies are tracked correctly', () => {
-    //   const ctx1 = createContext('default1');
-    //   const ctx2 = createContext('default2');
-
-    //   const computed1 = create1(() => {
-    //     // Only depends on ctx1
-    //     return useContext(ctx1);
-    //   });
-
-    //   const computed2 = create2(() => {
-    //     // Depends on both contexts
-    //     return computed1() + useContext(ctx2);
-    //   });
-
-    //   expect(computed2).toHaveValueAndCounts('default1default2', { compute: 1 });
-    //   expect(computed1).toHaveCounts({ compute: 1 });
-
-    //   expect(computed2).withContexts([ctx1, 'override1']).toHaveValueAndCounts('override1default2', { compute: 2 });
-    //   expect(computed1).toHaveCounts({ compute: 2 });
-
-    //   expect(computed2).withContexts([ctx2, 'override2']).toHaveValueAndCounts('default1override2', { compute: 3 });
-    //   expect(computed1).toHaveCounts({ compute: 2 });
-
-    //   expect(computed2)
-    //     .withContexts([ctx1, 'override1'], [ctx2, 'override2'])
-    //     .toHaveValueAndCounts('override1override2', { compute: 4 });
-    //   expect(computed1).toHaveCounts({ compute: 3 });
-
-    //   // Should reuse cached value since ctx2 didn't change
-    //   expect(computed1).withContexts([ctx2, 'override1']).toHaveValueAndCounts('default1', { compute: 3 });
-    // });
-
     test('context scopes inherit from parent scope when nested in computeds', async () => {
-      const ctx1 = createContext('default1');
-      const ctx2 = createContext('default2');
+      const ctx1 = context('default1');
+      const ctx2 = context('default2');
 
       const computed1 = create1(() => {
         return getContext(ctx1) + getContext(ctx2);
@@ -414,206 +269,4 @@ describe('contexts', () => {
       expect(computed1).toMatchSnapshot();
     });
   });
-
-  // permute(3, (create1, create2, create3) => {
-  //   test.skip('the gauntlet (params + state + context)', async () => {
-  //     const ctx = createContext('ctxdefault');
-  //     const value = signal('value');
-
-  //     const inner1 = create1((a: number) => {
-  //       if (a === 3) {
-  //         return ['inner1', useContext(ctx)];
-  //       } else if (a === 4) {
-  //         return ['inner1', value.get()];
-  //       }
-
-  //       return ['inner1'];
-  //     });
-
-  //     const inner2 = create2((a: number) => {
-  //       if (a === 3) {
-  //         return value.get() === 'value' ? ['inner2'] : ['inner2', useContext(ctx)];
-  //       } else if (a === 4) {
-  //         return withContexts([[ctx, 'ctxinneroverride']], () => {
-  //           return ['inner2', inner1(3), value.get()];
-  //         });
-  //       }
-
-  //       return ['inner2', inner1(a)];
-  //     });
-
-  //     const outer = create3((a: number) => {
-  //       if (a === 1) {
-  //         return [inner1(1), inner2(2)];
-  //       } else if (a === 2) {
-  //         return [inner1(2), inner2(3)];
-  //       } else if (a === 3) {
-  //         return [inner1(3), inner2(4)];
-  //       } else if (a === 4) {
-  //         return [useContext(ctx), inner2(4)];
-  //       } else if (a === 5) {
-  //         return [inner1(5), value.get()];
-  //       }
-  //     });
-
-  //     // a === 1
-  //     expect(outer)
-  //       .withParams(1)
-  //       .toHaveValueAndCounts([['inner1'], ['inner2', ['inner1']]], { compute: 1 });
-  //     expect(inner1).toHaveCounts({ compute: 2 });
-  //     expect(inner2).toHaveCounts({ compute: 1 });
-
-  //     expect(outer)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .withParams(1)
-  //       .toHaveValueAndCounts([['inner1'], ['inner2', ['inner1']]], { compute: 1 });
-  //     expect(inner1).toHaveCounts({ compute: 2 });
-  //     expect(inner2).toHaveCounts({ compute: 1 });
-
-  //     // a === 2
-  //     expect(outer)
-  //       .withParams(2)
-  //       .toHaveValueAndCounts([['inner1'], ['inner2']], {
-  //         compute: 2,
-  //       });
-  //     expect(inner1).toHaveCounts({ compute: 2 });
-  //     expect(inner2).toHaveCounts({ compute: 2 });
-
-  //     expect(outer)
-  //       .withParams(2)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveValueAndCounts([['inner1'], ['inner2']], {
-  //         compute: 2,
-  //       });
-  //     expect(inner1).toHaveCounts({ compute: 2 });
-  //     expect(inner2).toHaveCounts({ compute: 2 });
-
-  //     // a === 3
-  //     expect(outer)
-  //       .withParams(3)
-  //       .toHaveValueAndCounts(
-  //         [
-  //           ['inner1', 'ctxdefault'],
-  //           ['inner2', ['inner1', 'ctxinneroverride'], 'value'],
-  //         ],
-  //         {
-  //           compute: 3,
-  //         },
-  //       );
-  //     expect(inner1).toHaveCounts({ compute: 4 });
-  //     expect(inner2).toHaveCounts({ compute: 3 });
-
-  //     expect(outer)
-  //       .withParams(3)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveValueAndCounts(
-  //         [
-  //           ['inner1', 'ctxoverride'],
-  //           ['inner2', ['inner1', 'ctxinneroverride'], 'value'],
-  //         ],
-  //         {
-  //           compute: 4,
-  //         },
-  //       );
-  //     expect(inner1).toHaveCounts({ compute: 6 });
-  //     expect(inner2).toHaveCounts({ compute: 4 });
-
-  //     // a === 4
-  //     expect(outer)
-  //       .withParams(4)
-  //       .toHaveValueAndCounts(['ctxdefault', ['inner2', ['inner1', 'ctxinneroverride'], 'value']], {
-  //         compute: 5,
-  //       });
-  //     expect(inner1).toHaveCounts({ compute: 6 });
-  //     expect(inner2).toHaveCounts({ compute: 4 });
-
-  //     expect(outer)
-  //       .withParams(4)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveValueAndCounts(['ctxoverride', ['inner2', ['inner1', 'ctxinneroverride'], 'value']], {
-  //         compute: 6,
-  //       });
-  //     expect(inner1).toHaveCounts({ compute: 6 });
-  //     expect(inner2).toHaveCounts({ compute: 4 });
-
-  //     // a === 5
-  //     expect(outer)
-  //       .withParams(5)
-  //       .toHaveValueAndCounts([['inner1'], 'value'], {
-  //         compute: 7,
-  //       });
-  //     expect(inner1).toHaveCounts({ compute: 7 });
-  //     expect(inner2).toHaveCounts({ compute: 4 });
-
-  //     expect(outer)
-  //       .withParams(5)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveValueAndCounts([['inner1'], 'value'], {
-  //         compute: 8,
-  //       });
-  //     expect(inner1).toHaveCounts({ compute: 8 });
-  //     expect(inner2).toHaveCounts({ compute: 4 });
-
-  //     value.set('value2');
-  //     await nextTick();
-
-  //     // a === 1
-  //     expect(outer)
-  //       .withParams(1)
-  //       .toHaveSignalValue([['inner1'], ['inner2', ['inner1']]]);
-
-  //     expect(outer)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .withParams(1)
-  //       .toHaveSignalValue([['inner1'], ['inner2', ['inner1']]]);
-
-  //     // a === 2
-  //     expect(outer)
-  //       .withParams(2)
-  //       .toHaveSignalValue([['inner1'], ['inner2', 'ctxdefault']]);
-
-  //     expect(outer)
-  //       .withParams(2)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveSignalValue([['inner1'], ['inner2', 'ctxoverride']]);
-
-  //     // a === 3
-  //     expect(outer)
-  //       .withParams(3)
-  //       .toHaveSignalValue([
-  //         ['inner1', 'ctxdefault'],
-  //         ['inner2', ['inner1', 'ctxinneroverride'], 'value2'],
-  //       ]);
-
-  //     expect(outer)
-  //       .withParams(3)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveSignalValue([
-  //         ['inner1', 'ctxoverride'],
-  //         ['inner2', ['inner1', 'ctxinneroverride'], 'value2'],
-  //       ]);
-
-  //     // a === 4
-  //     expect(outer)
-  //       .withParams(4)
-  //       .toHaveSignalValue(['ctxdefault', ['inner2', ['inner1', 'ctxinneroverride'], 'value2']]);
-
-  //     expect(outer)
-  //       .withParams(4)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveSignalValue(['ctxoverride', ['inner2', ['inner1', 'ctxinneroverride'], 'value2']]);
-
-  //     // a === 5
-  //     expect(outer)
-  //       .withParams(5)
-  //       .toHaveSignalValue([['inner1'], 'value2']);
-  //     expect(outer)
-  //       .withParams(5)
-  //       .withContexts([ctx, 'ctxoverride'])
-  //       .toHaveSignalValue([['inner1'], 'value2']);
-
-  //     expect(inner1).toHaveCounts({ compute: 10 });
-  //     expect(inner2).toHaveCounts({ compute: 9 });
-  //   });
-  // });
 });

--- a/packages/signalium/src/__tests__/reactive-method-async.test.ts
+++ b/packages/signalium/src/__tests__/reactive-method-async.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'vitest';
+import { context, getContext, withContexts, signal, reactiveMethod } from '../index.js';
+import { nextTick, sleep } from './utils/async.js';
+
+describe('reactiveMethod (async)', () => {
+  test('basic async method resolves and uses owner scope across await', async () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const LabelCtx = context('default', 'label');
+
+    class Owner {
+      method = reactiveMethod(this, async () => {
+        const label = getContext(LabelCtx);
+        await nextTick();
+        return 'value-' + label;
+      });
+    }
+
+    const owner = new Owner();
+
+    // Register owner + label in a scope
+    withContexts(
+      [
+        [OwnerCtx, owner],
+        [LabelCtx, 'owned'],
+      ],
+      () => {},
+    );
+
+    const result1 = owner.method();
+    expect(result1.isPending).toBe(true);
+    expect(result1.value).toBe(undefined);
+    await sleep(10);
+    expect(result1.isResolved).toBe(true);
+    expect(result1.value).toBe('value-owned');
+
+    // Ambient override should not affect owner-scoped method
+    const result2 = withContexts([[LabelCtx, 'other']], () => owner.method());
+    await sleep(10);
+    expect(result2.isResolved).toBe(true);
+    expect(result2.value).toBe('value-owned');
+  });
+
+  test('async method caches per-args and recomputes when args change', async () => {
+    let computeCount = 0;
+    class Owner {
+      sum = reactiveMethod(this, async (a: number, b: number) => {
+        computeCount++;
+        await nextTick();
+        return a + b;
+      });
+    }
+
+    const owner = new Owner();
+
+    const OwnerCtx = context<object | null>(null, 'owner');
+    withContexts([[OwnerCtx, owner]], () => {});
+
+    const r1 = owner.sum(1, 2);
+    await sleep(10);
+    expect(r1.value).toBe(3);
+    expect(computeCount).toBe(1);
+
+    const r2 = owner.sum(1, 2);
+    await sleep(10);
+    expect(r2.value).toBe(3);
+    expect(computeCount).toBe(1);
+
+    const r3 = owner.sum(2, 2);
+    await sleep(10);
+    expect(r3.value).toBe(4);
+    expect(computeCount).toBe(2);
+  });
+
+  test('async method recomputes when state used changes', async () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const count = signal(1);
+    let computeCount = 0;
+    class Owner {
+      method = reactiveMethod(this, async (x: number) => {
+        computeCount++;
+        const c = count.value;
+        await nextTick();
+        return x + c;
+      });
+    }
+
+    const owner = new Owner();
+    withContexts([[OwnerCtx, owner]], () => {});
+
+    const r1 = owner.method(1);
+    await sleep(10);
+    expect(r1.value).toBe(2);
+    expect(computeCount).toBe(1);
+
+    count.value = 2;
+    const r2 = owner.method(1);
+    expect(r2.isPending).toBe(true);
+    await sleep(10);
+    expect(r2.value).toBe(3);
+    expect(computeCount).toBe(2);
+  });
+
+  test('different owners have independent async caches and contexts', async () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const LabelCtx = context(signal('default'), 'label');
+
+    const labelA = signal('A');
+    const labelB = signal('B');
+
+    class Owner {
+      constructor(public label: string) {}
+
+      method = reactiveMethod(this, async () => {
+        const label = getContext(LabelCtx).value;
+        await nextTick();
+        return label;
+      });
+    }
+
+    const ownerA = new Owner('A');
+    const ownerB = new Owner('B');
+
+    // Register two separate owner scopes
+    withContexts(
+      [
+        [OwnerCtx, ownerA],
+        [LabelCtx, labelA],
+      ],
+      () => {},
+    );
+
+    withContexts(
+      [
+        [OwnerCtx, ownerB],
+        [LabelCtx, labelB],
+      ],
+      () => {},
+    );
+
+    const rA1 = ownerA.method();
+    const rB1 = ownerB.method();
+    await sleep(10);
+    expect(rA1.value).toBe('A');
+    expect(rB1.value).toBe('B');
+
+    labelA.value = 'AA';
+    const rA2 = ownerA.method();
+    await sleep(10);
+    expect(rA2.value).toBe('AA');
+    const rB2 = ownerB.method();
+    await sleep(10);
+    expect(rB2.value).toBe('B');
+  });
+});

--- a/packages/signalium/src/__tests__/reactive-method.test.ts
+++ b/packages/signalium/src/__tests__/reactive-method.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'vitest';
+import { context, withContexts, getContext, reactiveMethod } from 'signalium';
+
+describe('reactiveMethod', () => {
+  test('uses the owner scope rather than the ambient scope', () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const LabelCtx = context('default', 'label');
+
+    // Establish an owner scope that maps the owner object and provides a label
+    class Owner {
+      method = reactiveMethod(this, () => getContext(LabelCtx));
+    }
+
+    const owner = new Owner();
+
+    withContexts(
+      [
+        [OwnerCtx, owner],
+        [LabelCtx, 'owned'],
+      ],
+      () => {},
+    );
+
+    // Called in global/ambient scope – should still use the owner's scope
+    expect(owner.method()).toBe('owned');
+
+    // Called inside a different ambient scope – should still use the owner's scope
+    const resultInOtherScope = withContexts([[LabelCtx, 'other']], () => owner.method());
+    expect(resultInOtherScope).toBe('owned');
+  });
+
+  test('throws if called for an owner with no associated scope', () => {
+    class Owner {
+      method = reactiveMethod(this, () => 123);
+    }
+
+    const owner = new Owner();
+
+    expect(() => owner.method()).toThrow('reactiveMethods must be attached to an owned context object');
+  });
+
+  test('caches like a standard reactive function (per owner, per args)', () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const LabelCtx = context('X', 'label');
+
+    let computeCount = 0;
+    class Owner {
+      method = reactiveMethod(this, (a: number, b: number) => {
+        computeCount++;
+        return `${getContext(LabelCtx)}:${a + b}`;
+      });
+    }
+
+    const owner = new Owner();
+
+    withContexts(
+      [
+        [OwnerCtx, owner],
+        [LabelCtx, 'X'],
+      ],
+      () => {},
+    );
+
+    expect(owner.method(1, 2)).toBe('X:3');
+    expect(computeCount).toBe(1);
+
+    // Same args -> cached
+    expect(owner.method(1, 2)).toBe('X:3');
+    expect(computeCount).toBe(1);
+
+    // Different args -> recomputed
+    expect(owner.method(2, 2)).toBe('X:4');
+    expect(computeCount).toBe(2);
+  });
+
+  test('different owners have independent scopes and caches', () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const LabelCtx = context('default', 'label');
+
+    class Owner {
+      constructor(public label: string) {}
+
+      count = 0;
+      method = reactiveMethod(this, (x: number) => {
+        this.count++;
+        return `${getContext(LabelCtx)}:${x}`;
+      });
+    }
+
+    const ownerA = new Owner('A');
+    const ownerB = new Owner('B');
+
+    // Establish owner A scope
+    withContexts(
+      [
+        [OwnerCtx, ownerA],
+        [LabelCtx, 'A'],
+      ],
+      () => {},
+    );
+
+    // Establish owner B scope
+    withContexts(
+      [
+        [OwnerCtx, ownerB],
+        [LabelCtx, 'B'],
+      ],
+      () => {},
+    );
+
+    // Initial calls compute once per owner
+    expect(ownerA.method(1)).toBe('A:1');
+    expect(ownerB.method(1)).toBe('B:1');
+    expect(ownerA.count).toBe(1);
+    expect(ownerB.count).toBe(1);
+
+    // Repeat with same args -> cached independently
+    expect(ownerA.method(1)).toBe('A:1');
+    expect(ownerB.method(1)).toBe('B:1');
+    expect(ownerA.count).toBe(1);
+    expect(ownerB.count).toBe(1);
+
+    // Change args per owner -> recompute per owner only
+    expect(ownerA.method(2)).toBe('A:2');
+    expect(ownerB.method(3)).toBe('B:3');
+    expect(ownerA.count).toBe(2);
+    expect(ownerB.count).toBe(2);
+
+    // Ambient override should not affect owner-scoped method
+    const inOther = withContexts([[LabelCtx, 'Z']], () => [ownerA.method(2), ownerB.method(3)]);
+    expect(inOther[0]).toBe('A:2');
+    expect(inOther[1]).toBe('B:3');
+  });
+});

--- a/packages/signalium/src/__tests__/utils/instrumented-hooks.ts
+++ b/packages/signalium/src/__tests__/utils/instrumented-hooks.ts
@@ -8,7 +8,7 @@ import {
   watcher,
 } from '../../index.js';
 import { TaskSignal, SignalValue, SignalOptionsWithInit, RelayHooks } from '../../types.js';
-import { Context, ContextImpl, getCurrentScope, ROOT_SCOPE, SignalScope } from '../../internals/contexts.js';
+import { Context, ContextImpl, getCurrentScope, GLOBAL_SCOPE, SignalScope } from '../../internals/contexts.js';
 import { ReactiveFnSignal } from '../../internals/reactive.js';
 import { AsyncSignalImpl } from '../../internals/async.js';
 import { hashValue } from '../../internals/utils/hash.js';
@@ -308,7 +308,7 @@ function createBuilderFunction<T, Args extends unknown[]>(
     return createBuilderFunction(originalFn, countsMap, args as Args, withContexts) as ReactiveBuilderFunction<T, Args>;
   };
 
-  const scope = contexts ? ROOT_SCOPE.getChild(contexts as [ContextImpl<unknown>, unknown][]) : ROOT_SCOPE;
+  const scope = contexts ? GLOBAL_SCOPE.getChild(contexts as [ContextImpl<unknown>, unknown][]) : GLOBAL_SCOPE;
   builderFn[COUNTS] = getCountsFor(originalFn.name, countsMap, scope, args);
 
   return builderFn;

--- a/packages/signalium/src/index.ts
+++ b/packages/signalium/src/index.ts
@@ -1,6 +1,6 @@
 export type * from './types.js';
 
-export { reactive, relay, task, watcher } from './hooks.js';
+export { reactive, reactiveMethod, relay, task, watcher } from './core-api.js';
 
 export { signal } from './internals/signal.js';
 
@@ -9,11 +9,11 @@ export { isAsyncSignal, isTaskSignal, isRelaySignal } from './internals/async.js
 export { callback } from './internals/callback.js';
 
 export {
-  context as createContext,
+  context,
   getContext,
   withContexts,
-  setRootContexts,
-  clearRootContexts,
+  setGlobalContexts,
+  clearGlobalContexts,
   SignalScope,
 } from './internals/contexts.js';
 

--- a/packages/signalium/src/internals/contexts.ts
+++ b/packages/signalium/src/internals/contexts.ts
@@ -76,6 +76,10 @@ export class SignalScope {
   setContexts(contexts: [ContextImpl<unknown>, unknown][]) {
     for (const [context, value] of contexts) {
       this.contexts[context._key] = value;
+
+      if (typeof value === 'object' && value !== null) {
+        OWNER_SCOPE_MAP.set(value, this);
+      }
     }
 
     this.signals.clear();
@@ -143,14 +147,14 @@ export class SignalScope {
   }
 }
 
-export let ROOT_SCOPE = new SignalScope([]);
+export let GLOBAL_SCOPE = new SignalScope([]);
 
-export function setRootContexts<C extends unknown[], U>(contexts: [...ContextPair<C>]): void {
-  ROOT_SCOPE.setContexts(contexts as [ContextImpl<unknown>, unknown][]);
+export function setGlobalContexts<C extends unknown[], U>(contexts: [...ContextPair<C>]): void {
+  GLOBAL_SCOPE.setContexts(contexts as [ContextImpl<unknown>, unknown][]);
 }
 
-export const clearRootContexts = () => {
-  ROOT_SCOPE = new SignalScope([]);
+export const clearGlobalContexts = () => {
+  GLOBAL_SCOPE = new SignalScope([]);
 };
 
 export let CURRENT_SCOPE: SignalScope | undefined;
@@ -160,7 +164,15 @@ export const setCurrentScope = (scope: SignalScope | undefined) => {
 };
 
 export const getCurrentScope = (): SignalScope => {
-  return CURRENT_SCOPE ?? CURRENT_CONSUMER?.scope ?? ROOT_SCOPE;
+  return CURRENT_SCOPE ?? CURRENT_CONSUMER?.scope ?? GLOBAL_SCOPE;
+};
+
+// ======= Owner =======
+
+const OWNER_SCOPE_MAP = new Map<object, SignalScope>();
+
+export const getOwner = (owner: object): SignalScope | undefined => {
+  return OWNER_SCOPE_MAP.get(owner);
 };
 
 // ======= Test Helper =======

--- a/packages/signalium/src/internals/scheduling.ts
+++ b/packages/signalium/src/internals/scheduling.ts
@@ -6,7 +6,7 @@ import { runListeners as runStateListeners } from './signal.js';
 import { Tracer } from '../trace.js';
 import { unwatchSignal } from './watch.js';
 import { StateSignal } from './signal.js';
-import { ROOT_SCOPE, SignalScope } from './contexts.js';
+import { SignalScope } from './contexts.js';
 
 // Determine once at startup which scheduling function to use for GC
 const scheduleIdleCallback =

--- a/packages/signalium/src/react/__tests__/callbacks.test.tsx
+++ b/packages/signalium/src/react/__tests__/callbacks.test.tsx
@@ -2,15 +2,14 @@ import { describe, expect, test } from 'vitest';
 import React, { useCallback, useState } from 'react';
 import { render } from 'vitest-browser-react';
 import { userEvent } from '@vitest/browser/context';
-import { signal, reactive, createContext, getContext } from 'signalium';
-import { ContextProvider, useSignal } from '../index.js';
-import { component } from 'signalium/react';
+import { signal, reactive, context, getContext } from 'signalium';
+import { component, useSignal, ContextProvider } from 'signalium/react';
 import { createRenderCounter } from './utils.js';
 import { sleep } from '../../__tests__/utils/async.js';
 
 describe('React > callbacks inside component()', () => {
   test('callback created in component has correct scope with contexts', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const Show = component(() => {
       const [ctxValue, setCtxValue] = useState('default');
@@ -32,7 +31,7 @@ describe('React > callbacks inside component()', () => {
   });
 
   test('callback created in component has correct scope with contexts', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const inner = reactive(() => getContext(ctx));
 
@@ -67,7 +66,7 @@ describe('React > callbacks inside component()', () => {
   });
 
   test('callback created in component reactive compute has correct scope with contexts', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const inner = reactive(() => getContext(ctx));
     const makeCb = reactive(() => () => inner());
@@ -92,7 +91,7 @@ describe('React > callbacks inside component()', () => {
   });
 
   test('nested callbacks in reactives maintain scope across levels in component', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const inner = reactive(() => getContext(ctx));
 
@@ -162,7 +161,7 @@ describe('React > callbacks inside component()', () => {
   });
 
   test('async callback maintains captured scope after await in component', async () => {
-    const ctx = createContext('default');
+    const ctx = context('default');
 
     const makeAsyncCb = reactive(() => async () => {
       await sleep(10);

--- a/packages/signalium/src/react/__tests__/contexts.test.tsx
+++ b/packages/signalium/src/react/__tests__/contexts.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { render } from 'vitest-browser-react';
-import { signal, reactive, createContext, setRootContexts } from '../../index.js';
+import { signal, reactive, context, setGlobalContexts } from '../../index.js';
 import { ContextProvider, useReactive, useContext } from '../index.js';
 import React from 'react';
 import { useScope } from '../context.js';
@@ -8,9 +8,9 @@ import { useScope } from '../context.js';
 describe('React > contexts', () => {
   test('useContext works inside computed with default value', async () => {
     const value = signal('Hello');
-    const context = createContext(value);
+    const ctx = context(value);
 
-    const derived = reactive(() => `${useContext(context).value}, World`);
+    const derived = reactive(() => `${useContext(ctx).value}, World`);
 
     function Component(): React.ReactNode {
       return <div>{useReactive(derived)}</div>;
@@ -27,10 +27,10 @@ describe('React > contexts', () => {
 
   test('useContext works at root level with default value', async () => {
     const value = signal('Hello');
-    const context = createContext(value);
+    const ctx = context(value);
 
     function Component(): React.ReactNode {
-      const v = useContext(context);
+      const v = useContext(ctx);
 
       return <div>{useReactive(v)}, World</div>;
     }
@@ -51,13 +51,13 @@ describe('React > contexts', () => {
   test('provider inherits from root scope', async () => {
     const defaultValue1 = signal('default1');
     const defaultValue2 = signal('default2');
-    const ctx1 = createContext(defaultValue1);
-    const ctx2 = createContext(defaultValue2);
+    const ctx1 = context(defaultValue1);
+    const ctx2 = context(defaultValue2);
     const rootOverride1 = signal('root1');
     const rootOverride2 = signal('root2');
 
     // Set root contexts
-    setRootContexts([
+    setGlobalContexts([
       [ctx1, rootOverride1],
       [ctx2, rootOverride2],
     ]);
@@ -114,16 +114,16 @@ describe('React > contexts', () => {
   test('useContext works inside computed value passed via context provider', async () => {
     const value = signal('Hello');
     const override = signal('Hey');
-    const context = createContext(value);
+    const ctx = context(value);
 
-    const derived = reactive(() => `${useContext(context).value}, World`);
+    const derived = reactive(() => `${useContext(ctx).value}, World`);
 
     function Component(): React.ReactNode {
       return <div>{useReactive(derived)}</div>;
     }
 
     const { getByText } = render(
-      <ContextProvider contexts={[[context, override]]}>
+      <ContextProvider contexts={[[ctx, override]]}>
         <Component />
       </ContextProvider>,
     );
@@ -138,16 +138,16 @@ describe('React > contexts', () => {
   test('useContext works at root level with default value', async () => {
     const value = signal('Hello');
     const override = signal('Hey');
-    const context = createContext(value);
+    const ctx = context(value);
 
     function Component(): React.ReactNode {
-      const v = useContext(context);
+      const v = useContext(ctx);
 
       return <div>{useReactive(v)}, World</div>;
     }
 
     const { getByText } = render(
-      <ContextProvider contexts={[[context, override]]}>
+      <ContextProvider contexts={[[ctx, override]]}>
         <Component />
       </ContextProvider>,
     );

--- a/packages/signalium/src/react/__tests__/methods.test.tsx
+++ b/packages/signalium/src/react/__tests__/methods.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest';
+import { render } from 'vitest-browser-react';
+import React from 'react';
+
+import { context, signal, reactive } from '../../index.js';
+import { reactiveMethod } from 'signalium';
+import { ContextProvider, useReactive, useContext } from '../index.js';
+
+describe('React > reactiveMethod', () => {
+  test('uses owner scope even when ambient scope differs', async () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const LabelCtx = context('default', 'label');
+
+    class Owner {
+      method = reactiveMethod(this, () => useContext(LabelCtx));
+    }
+
+    const owner = new Owner();
+    const derived = reactive(() => owner.method());
+
+    const Derived = () => {
+      const value = useReactive(derived);
+      return <div data-testid="value">{value}</div>;
+    };
+
+    const App = () => (
+      <ContextProvider
+        contexts={[
+          [OwnerCtx, owner],
+          [LabelCtx, 'owned'],
+        ]}
+      >
+        {/* Ambient override should not affect the method bound to owner */}
+        <ContextProvider contexts={[[LabelCtx, 'other']]}>
+          <Derived />
+        </ContextProvider>
+      </ContextProvider>
+    );
+
+    const { getByTestId } = render(<App />);
+    await expect.element(getByTestId('value')).toHaveTextContent('owned');
+  });
+
+  test('different owners compute independently and update reactively', async () => {
+    const OwnerCtx = context<object | null>(null, 'owner');
+    const LabelCtx = context(signal('default'), 'label');
+
+    const labelA = signal('A');
+    const labelB = signal('B');
+
+    class Owner {
+      value = reactiveMethod(this, () => useContext(LabelCtx).value);
+    }
+
+    const ownerA = new Owner();
+    const ownerB = new Owner();
+    const derivedA = reactive(() => ownerA.value());
+    const derivedB = reactive(() => ownerB.value());
+
+    const View = ({ id, method }: { id: string; method: () => string }) => {
+      const value = useReactive(method === ownerA.value ? derivedA : derivedB);
+      return <div data-testid={id}>{value}</div>;
+    };
+
+    const { getByTestId } = render(
+      <>
+        <ContextProvider
+          contexts={[
+            [OwnerCtx, ownerA],
+            [LabelCtx, labelA],
+          ]}
+        >
+          <View id="a" method={ownerA.value} />
+        </ContextProvider>
+        <ContextProvider
+          contexts={[
+            [OwnerCtx, ownerB],
+            [LabelCtx, labelB],
+          ]}
+        >
+          <View id="b" method={ownerB.value} />
+        </ContextProvider>
+      </>,
+    );
+
+    await expect.element(getByTestId('a')).toHaveTextContent('A');
+    await expect.element(getByTestId('b')).toHaveTextContent('B');
+
+    labelA.value = 'AA';
+    await expect.element(getByTestId('a')).toHaveTextContent('AA');
+    await expect.element(getByTestId('b')).toHaveTextContent('B');
+
+    labelB.value = 'BB';
+    await expect.element(getByTestId('a')).toHaveTextContent('AA');
+    await expect.element(getByTestId('b')).toHaveTextContent('BB');
+  });
+});

--- a/packages/signalium/src/react/provider.tsx
+++ b/packages/signalium/src/react/provider.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { ScopeContext } from './context.js';
-import { ContextImpl, ContextPair, ROOT_SCOPE, SignalScope } from '../internals/contexts.js';
+import { ContextImpl, ContextPair, GLOBAL_SCOPE, SignalScope } from '../internals/contexts.js';
 
 export function ContextProvider<C extends unknown[]>({
   children,
@@ -11,7 +11,7 @@ export function ContextProvider<C extends unknown[]>({
   contexts?: [...ContextPair<C>] | [];
   inherit?: boolean;
 }) {
-  const parentScope = useContext(ScopeContext) ?? ROOT_SCOPE;
+  const parentScope = useContext(ScopeContext) ?? GLOBAL_SCOPE;
   const scope = new SignalScope(contexts as [ContextImpl<unknown>, unknown][], inherit ? parentScope : undefined);
 
   return <ScopeContext.Provider value={scope}>{children}</ScopeContext.Provider>;

--- a/packages/signalium/src/react/use-reactive.ts
+++ b/packages/signalium/src/react/use-reactive.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useCallback, useSyncExternalStore } from 'react';
 import { RelaySignal, AsyncSignal, SignalValue, Signal } from '../types.js';
-import { DERIVED_DEFINITION_MAP } from '../hooks.js';
+import { DERIVED_DEFINITION_MAP } from '../core-api.js';
 import { expect } from '../type-utils.js';
 import { isRelaySignal } from '../internals/async.js';
 import { CURRENT_CONSUMER } from '../internals/consumer.js';
@@ -10,7 +10,7 @@ import { isAsyncSignalImpl } from '../internals/utils/type-utils.js';
 import { AsyncSignalImpl } from '../internals/async.js';
 import { StateSignal } from '../internals/signal.js';
 import { useScope } from './context.js';
-import { ROOT_SCOPE } from '../internals/contexts.js';
+import { GLOBAL_SCOPE } from '../internals/contexts.js';
 
 const useStateSignal = <T>(signal: StateSignal<T>): T => {
   return useSyncExternalStore(
@@ -41,7 +41,7 @@ const useAsyncSignal = <R>(promise: AsyncSignalImpl<R>): AsyncSignalImpl<R> => {
 const useReactiveFn = <R, Args extends readonly Narrowable[]>(fn: (...args: Args) => R, ...args: Args): R => {
   const def = expect(DERIVED_DEFINITION_MAP.get(fn), 'Expected to find a derived definition for the function');
 
-  const scope = useScope() ?? ROOT_SCOPE;
+  const scope = useScope() ?? GLOBAL_SCOPE;
 
   const signal = scope.get(def, args);
   const value = useReactiveFnSignal(signal);

--- a/packages/signalium/src/transform/async.ts
+++ b/packages/signalium/src/transform/async.ts
@@ -8,6 +8,7 @@ export function signaliumAsyncTransform(opts?: SignaliumAsyncTransformOptions): 
   const transformedImports: Record<string, [string | RegExp]> = {
     callback: ['signalium'],
     reactive: ['signalium'],
+    reactiveMethod: ['signalium'],
     relay: ['signalium'],
     task: ['signalium'],
   };

--- a/packages/signalium/src/transform/callback.ts
+++ b/packages/signalium/src/transform/callback.ts
@@ -8,6 +8,7 @@ export function signaliumCallbackTransform(opts?: SignaliumCallbackTransformOpti
   const transformedImports: Record<string, [string | RegExp]> = {
     component: ['signalium/react'],
     reactive: ['signalium'],
+    reactiveMethod: ['signalium'],
     relay: ['signalium'],
     task: ['signalium'],
   };


### PR DESCRIPTION
Currently, if you make a reactive method on a class, the method still looks itself up on the scope as if it were a normal function. This results in some weird behaviors:

```ts
// Standard usage

const ctx = context('default')

const foo = reactive(() => {
  return useContext(ctx);
});

foo(); // 'default'

withContexts([ctx, 'override'], () => {
  foo(); // 'override'
});

// But what about context classes?

const otherCtx = context('other');

class MyContext {
  foo = reactive(() => {
    return useContext(otherCtx);
  });
}

const myCtx = new MyContext();

withContexts([ctx, myCtx], () => {
  const myCtx = useContext(myCtx);

  myCtx.foo(); // 'default'

  withContexts([otherCtx, 'override'], () => {
    // seems weird
    myCtx.foo(); // 'override'
  });
});
```

`reactiveMethod` is a way to make a function that is owned by a class:

```ts
const otherCtx = context('other');

class MyContext {
  foo = reactiveMethod(this, () => {
    return useContext(otherCtx);
  });
}

const myCtx = new MyContext();

withContexts([ctx, myCtx], () => {
  const myCtx = useContext(myCtx);

  myCtx.foo(); // 'default'

  withContexts([otherCtx, 'override'], () => {
    myCtx.foo(); // 'default'
  });
});
```

This currently only works with contexts. Objects that are assigned to contexts become owned, and methods execute in with that owner.

In the future, one possibility is to update `reactive` to be a decorator. I decided not to add a dependency on that just yet, especially because typing is still weird I think. But it would be nicer, most likely:

```ts
class MyContext {
  @reactive
  foo() {
    return useContext(otherCtx);
  }
}
```