### PR TITLE
Make Signalium bump a patch

### DIFF
--- a/.changeset/angry-lies-judge.md
+++ b/.changeset/angry-lies-judge.md
@@ -1,5 +1,5 @@
 ---
-'signalium': minor
+'signalium': patch
 '@signalium/query': patch
 ---
 


### PR DESCRIPTION
There is an issue with changesets that's causing major version bumps on minor peer dep bumps. We don't want that behavior at the moment, so we're going to update it to be a patch for now: https://github.com/changesets/changesets/pull/1132