### PR TITLE
Ensure async reactive cleanup happens after promises settle

### DIFF
--- a/.changeset/deep-dryers-win.md
+++ b/.changeset/deep-dryers-win.md
@@ -1,0 +1,5 @@
+---
+'signalium': patch
+---
+
+Ensure async reactive cleanup happens after promises settle

--- a/packages/signalium/src/__tests__/reactive-async.test.ts
+++ b/packages/signalium/src/__tests__/reactive-async.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { signal } from 'signalium';
-import { reactive } from './utils/instrumented-hooks.js';
-import { nextTick } from './utils/async.js';
+import { reactive, relay } from './utils/instrumented-hooks.js';
+import { nextTick, sleep } from './utils/async.js';
 
 describe('async computeds', () => {
   test('Basic async computed works', async () => {
@@ -567,5 +567,689 @@ describe('async computeds', () => {
     expect(r2.value).toBe(4);
     expect(innerCount).toBe(2);
     expect(outerCount).toBe(1);
+  });
+
+  describe('dependency pruning during async rerun', () => {
+    test('dependencies consumed after an await are NOT disconnected when the function reruns due to being directly dirtied', async () => {
+      // This test verifies that dependencies consumed after an await point are not
+      // prematurely disconnected when the async function reruns.
+      //
+      // The bug: When an async function reruns due to a direct dirty (not MaybeDirty),
+      // the synchronous part runs, then disconnectSignal is called in the finally block.
+      // This disconnects any dependencies that weren't consumed yet (i.e., those after the await).
+
+      let inner1Count = 0;
+      let inner2Count = 0;
+      let outerCount = 0;
+
+      const state1 = signal(1);
+      const state2 = signal(2);
+
+      // inner1 is consumed BEFORE the await
+      const inner1 = reactive(
+        async () => {
+          inner1Count++;
+          return state1.value * 10;
+        },
+        { desc: 'inner1' },
+      );
+
+      // inner2 is consumed AFTER the await
+      const inner2 = reactive(
+        async () => {
+          inner2Count++;
+          return state2.value * 100;
+        },
+        { desc: 'inner2' },
+      );
+
+      const outer = reactive(
+        async () => {
+          outerCount++;
+          // Consume inner1 before the await
+          const val1 = await inner1();
+
+          await sleep(10);
+          // Consume inner2 after the await
+          const val2 = await inner2();
+          return val1 + val2;
+        },
+        { desc: 'outer' },
+      );
+
+      // Initial run
+      const r1 = outer();
+      expect(r1.isPending).toBe(true);
+      await sleep(20);
+      expect(r1.isResolved).toBe(true);
+      expect(r1.value).toBe(210); // 1*10 + 2*100
+      expect(inner1Count).toBe(1);
+      expect(inner2Count).toBe(1);
+      expect(outerCount).toBe(1);
+
+      // Now directly dirty the outer function by changing state1
+      // This will cause outer to rerun
+      state1.value = 2;
+
+      const r2 = outer();
+      expect(r2.isPending).toBe(true);
+      expect(inner1Count).toBe(2); // inner1 reran because state1 changed
+
+      // At this point, the outer function has started its rerun:
+      // - It consumed inner1 (before the await)
+      // - It has NOT yet consumed inner2 (after the await)
+      //
+      // BUG: inner2 should NOT be disconnected/unwatched at this point,
+      // but the current implementation calls disconnectSignal immediately
+      // after the synchronous part completes.
+
+      await sleep(20);
+      expect(r2.isResolved).toBe(true);
+      expect(r2.value).toBe(220); // 2*10 + 2*100
+
+      // inner2 should have been reused, NOT recreated
+      // If inner2 was disconnected and garbage collected, it would have been
+      // recreated, causing inner2Count to increment unnecessarily
+      expect(inner2Count).toBe(1); // Should still be 1 - inner2 wasn't dirtied
+      expect(outerCount).toBe(2);
+    });
+
+    test('dependencies should only be pruned after async function fully resolves', async () => {
+      // This test specifically checks that unused dependencies are only pruned
+      // AFTER the promise has fully resolved, not during the async execution.
+
+      let dep1Count = 0;
+      let dep2Count = 0;
+      let outerCount = 0;
+
+      const useDep1 = signal(true);
+      const state1 = signal(1);
+      const state2 = signal(2);
+
+      const dep1 = reactive(
+        async () => {
+          dep1Count++;
+          return state1.value * 10;
+        },
+        { desc: 'dep1' },
+      );
+
+      const dep2 = reactive(
+        async () => {
+          dep2Count++;
+          return state2.value * 100;
+        },
+        { desc: 'dep2' },
+      );
+
+      const outer = reactive(
+        async () => {
+          outerCount++;
+          // First await
+          const val1 = await dep1();
+          await sleep(10);
+          // Conditionally consume dep2 after the await
+          if (useDep1.value) {
+            const val2 = await dep2();
+            return val1 + val2;
+          }
+          return val1;
+        },
+        { desc: 'outer' },
+      );
+
+      // Initial run with useDep1 = true
+      const r1 = outer();
+      await sleep(20);
+      expect(r1.value).toBe(210);
+      expect(dep1Count).toBe(1);
+      expect(dep2Count).toBe(1);
+      expect(outerCount).toBe(1);
+
+      // Now change useDep1 to false - this dirties outer
+      useDep1.value = false;
+
+      const r2 = outer();
+      expect(r2.isPending).toBe(true);
+
+      await sleep(20);
+      expect(r2.isResolved).toBe(true);
+      expect(r2.value).toBe(10); // Only dep1 value now
+      expect(outerCount).toBe(2);
+
+      // dep2 should NOT have been recomputed during this rerun
+      // (it wasn't consumed this time and should have been disconnected)
+      expect(dep2Count).toBe(1);
+
+      // Now change useDep1 to true again
+      useDep1.value = true;
+
+      const r3 = outer();
+      expect(r3.isPending).toBe(true);
+
+      await sleep(20);
+      expect(r3.isResolved).toBe(true);
+      expect(r3.value).toBe(210); // 2*10 + 2*100
+
+      expect(dep2Count).toBe(2);
+    });
+
+    test('dependencies consumed after await should not be garbage collected during rerun', async () => {
+      // This test verifies that dependencies consumed after an await don't get
+      // scheduled for garbage collection during the rerun.
+
+      let innerCount = 0;
+      let outerCount = 0;
+
+      const trigger = signal(1);
+      const innerValue = signal(100);
+
+      const inner = reactive(
+        async () => {
+          innerCount++;
+          await nextTick();
+          return innerValue.value;
+        },
+        { desc: 'inner' },
+      );
+
+      const outer = reactive(
+        async () => {
+          outerCount++;
+          // Access trigger before await
+          const t = trigger.value;
+          await nextTick();
+          // Access inner after await
+          const v = await inner();
+          return t + v;
+        },
+        { desc: 'outer' },
+      );
+
+      // Initial run
+      const r1 = outer();
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(r1.value).toBe(101); // 1 + 100
+      expect(innerCount).toBe(1);
+      expect(outerCount).toBe(1);
+
+      // Dirty outer by changing trigger (consumed before await)
+      trigger.value = 2;
+
+      const r2 = outer();
+      expect(r2.isPending).toBe(true);
+
+      // Wait for the async execution to complete
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(r2.value).toBe(102); // 2 + 100
+      expect(outerCount).toBe(2);
+
+      // inner should NOT have been recreated/recomputed
+      // If it was garbage collected during the rerun, it would have been
+      // recreated, incrementing the count
+      expect(innerCount).toBe(1);
+
+      // Now verify that inner is still properly subscribed by changing innerValue
+      innerValue.value = 200;
+      const r3 = outer();
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(r3.value).toBe(202); // 2 + 200
+      expect(innerCount).toBe(2); // Now inner should recompute
+      expect(outerCount).toBe(3);
+    });
+
+    test('multiple awaits should preserve all dependencies until promise settles', async () => {
+      // Test with multiple sequential awaits to ensure all dependencies
+      // are preserved until the final resolution.
+
+      let dep1Count = 0;
+      let dep2Count = 0;
+      let dep3Count = 0;
+      let outerCount = 0;
+
+      const trigger = signal(0);
+
+      const dep1 = reactive(
+        async () => {
+          dep1Count++;
+          await nextTick();
+          return 'a';
+        },
+        { desc: 'dep1' },
+      );
+
+      const dep2 = reactive(
+        async () => {
+          dep2Count++;
+          await nextTick();
+          return 'b';
+        },
+        { desc: 'dep2' },
+      );
+
+      const dep3 = reactive(
+        async () => {
+          dep3Count++;
+          await nextTick();
+          return 'c';
+        },
+        { desc: 'dep3' },
+      );
+
+      const outer = reactive(
+        async () => {
+          outerCount++;
+          // Consume trigger first
+          const t = trigger.value;
+          // Then multiple sequential awaits
+          const v1 = await dep1();
+          await sleep(10);
+          const v2 = await dep2();
+          await sleep(10);
+          const v3 = await dep3();
+          await sleep(10);
+          return `${t}:${v1}${v2}${v3}`;
+        },
+        { desc: 'outer' },
+      );
+
+      // Initial run
+      const r1 = outer();
+      await sleep(60);
+      expect(r1.value).toBe('0:abc');
+      expect(dep1Count).toBe(1);
+      expect(dep2Count).toBe(1);
+      expect(dep3Count).toBe(1);
+      expect(outerCount).toBe(1);
+
+      // Dirty by changing trigger
+      trigger.value = 1;
+
+      const r2 = outer();
+      await sleep(60);
+      expect(r2.value).toBe('1:abc');
+      expect(outerCount).toBe(2);
+
+      // All deps should have been preserved, not recreated
+      expect(dep1Count).toBe(1);
+      expect(dep2Count).toBe(1);
+      expect(dep3Count).toBe(1);
+    });
+
+    describe('relay lifecycle during async rerun', () => {
+      test('relays consumed after an await should NOT be unsubscribed when the function reruns', async () => {
+        // This test verifies that relays consumed after an await point are not
+        // prematurely unsubscribed when the async function reruns.
+        //
+        // The bug: When an async function reruns due to a direct dirty,
+        // disconnectSignal is called after the synchronous part completes,
+        // which would unsubscribe relays that weren't consumed yet.
+
+        let outerCount = 0;
+        const trigger = signal(1);
+        const relayValue = signal(100);
+
+        // relay1 is consumed BEFORE the await
+        const relay1 = relay<number>(
+          state => {
+            state.value = trigger.value * 10;
+            return {
+              update: () => {
+                state.value = trigger.value * 10;
+              },
+              deactivate: () => {},
+            };
+          },
+          { desc: 'relay1' },
+        );
+
+        // relay2 is consumed AFTER the await
+        const relay2 = relay<number>(
+          state => {
+            state.value = relayValue.value;
+            return {
+              update: () => {
+                state.value = relayValue.value;
+              },
+              deactivate: () => {},
+            };
+          },
+          { desc: 'relay2' },
+        );
+
+        // Wrap relays in reactive functions so they can be properly consumed
+        const getRelay1 = reactive(
+          async () => {
+            return relay1.value;
+          },
+          { desc: 'getRelay1' },
+        );
+
+        const getRelay2 = reactive(
+          async () => {
+            return relay2.value;
+          },
+          { desc: 'getRelay2' },
+        );
+
+        const outer = reactive(
+          async () => {
+            outerCount++;
+            // Consume relay1 before the await
+            const val1 = await getRelay1();
+
+            await sleep(10);
+            // Consume relay2 after the await
+            const val2 = await getRelay2();
+            return val1! + val2!;
+          },
+          { desc: 'outer' },
+        );
+
+        // Initial run - use toHaveSignalValue which creates a watcher to activate relays
+        expect(outer).toHaveSignalValue(undefined);
+        await sleep(30);
+        expect(outer).toHaveSignalValue(110); // 1*10 + 100
+        expect(relay1).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(relay2).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(outerCount).toBe(1);
+
+        // Now directly dirty outer by changing trigger (consumed via relay1 before await)
+        trigger.value = 2;
+
+        // At this point, outer has started its rerun:
+        // - It consumed relay1 (before the await)
+        // - It has NOT yet consumed relay2 (after the await)
+        //
+        // BUG: relay2 should NOT be unsubscribed at this point
+
+        await sleep(30);
+        expect(outer).toHaveSignalValue(120); // 2*10 + 100
+
+        // relay2 should NOT have been unsubscribed and resubscribed
+        expect(relay2).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(outerCount).toBe(2);
+      });
+
+      test('relay consumed after plain await should not be unsubscribed during rerun', async () => {
+        // This tests the specific case where there's a plain await (like sleep)
+        // before consuming the relay
+
+        let outerCount = 0;
+        const trigger = signal(1);
+        const relayValue = signal(100);
+
+        const innerRelay = relay<number>(
+          state => {
+            state.value = relayValue.value;
+            return {
+              update: () => {
+                state.value = relayValue.value;
+              },
+              deactivate: () => {},
+            };
+          },
+          { desc: 'innerRelay' },
+        );
+
+        // Wrap relay in a reactive function for proper consumption
+        const getRelay = reactive(
+          async () => {
+            return innerRelay.value;
+          },
+          { desc: 'getRelay' },
+        );
+
+        const outer = reactive(
+          async () => {
+            outerCount++;
+            // Access trigger before await
+            const t = trigger.value;
+            await sleep(10);
+            // Access relay after await
+            const v = await getRelay();
+            return t + v!;
+          },
+          { desc: 'outer' },
+        );
+
+        // Initial run
+        expect(outer).toHaveSignalValue(undefined);
+        await sleep(30);
+        expect(outer).toHaveSignalValue(101); // 1 + 100
+        expect(innerRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(outerCount).toBe(1);
+
+        // Dirty outer by changing trigger (consumed before await)
+        trigger.value = 2;
+
+        await sleep(30);
+        expect(outer).toHaveSignalValue(102); // 2 + 100
+        expect(outerCount).toBe(2);
+
+        // innerRelay should NOT have been unsubscribed during the rerun
+        expect(innerRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+
+        // Now verify the relay is still properly subscribed by changing relayValue
+        relayValue.value = 200;
+        await sleep(30);
+        expect(outer).toHaveSignalValue(202); // 2 + 200
+        expect(outerCount).toBe(3);
+        // Relay should have been updated, not unsubscribed/resubscribed
+        expect(innerRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0, update: 1 });
+      });
+
+      test('multiple relays consumed after awaits should all remain subscribed', async () => {
+        // Test with multiple relays consumed at different points after awaits
+
+        let outerCount = 0;
+        const trigger = signal(0);
+
+        const relay1 = relay<string>(
+          state => {
+            state.value = 'a';
+            return { deactivate: () => {} };
+          },
+          { desc: 'relay1' },
+        );
+
+        const relay2 = relay<string>(
+          state => {
+            state.value = 'b';
+            return { deactivate: () => {} };
+          },
+          { desc: 'relay2' },
+        );
+
+        const relay3 = relay<string>(
+          state => {
+            state.value = 'c';
+            return { deactivate: () => {} };
+          },
+          { desc: 'relay3' },
+        );
+
+        // Wrap relays in reactive functions
+        const getRelay1 = reactive(async () => relay1.value, { desc: 'getRelay1' });
+        const getRelay2 = reactive(async () => relay2.value, { desc: 'getRelay2' });
+        const getRelay3 = reactive(async () => relay3.value, { desc: 'getRelay3' });
+
+        const outer = reactive(
+          async () => {
+            outerCount++;
+            // Consume trigger first
+            const t = trigger.value;
+            // Then multiple sequential awaits with relays
+            const v1 = await getRelay1();
+            await sleep(10);
+            const v2 = await getRelay2();
+            await sleep(10);
+            const v3 = await getRelay3();
+            await sleep(10);
+            return `${t}:${v1}${v2}${v3}`;
+          },
+          { desc: 'outer' },
+        );
+
+        // Initial run
+        expect(outer).toHaveSignalValue(undefined);
+        await sleep(80);
+        expect(outer).toHaveSignalValue('0:abc');
+        expect(relay1).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(relay2).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(relay3).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(outerCount).toBe(1);
+
+        // Dirty by changing trigger
+        trigger.value = 1;
+
+        await sleep(80);
+        expect(outer).toHaveSignalValue('1:abc');
+        expect(outerCount).toBe(2);
+
+        // All relays should remain subscribed, not unsubscribed/resubscribed
+        expect(relay1).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(relay2).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(relay3).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+      });
+
+      test('relay should only be unsubscribed after async function fully resolves when no longer used', async () => {
+        // This test verifies that relays are only unsubscribed after the promise
+        // has fully resolved, and only if they were not consumed in that run.
+
+        let outerCount = 0;
+        const useRelay = signal(true);
+
+        const conditionalRelay = relay<number>(
+          state => {
+            state.value = 42;
+            return {
+              update: () => {},
+              deactivate: () => {},
+            };
+          },
+          { desc: 'conditionalRelay' },
+        );
+
+        const alwaysUsedRelay = relay<number>(
+          state => {
+            state.value = 100;
+            return {
+              update: () => {},
+              deactivate: () => {},
+            };
+          },
+          { desc: 'alwaysUsedRelay' },
+        );
+
+        // Wrap relays in reactive functions
+        const getAlwaysRelay = reactive(async () => await alwaysUsedRelay, { desc: 'getAlwaysRelay' });
+        const getConditionalRelay = reactive(async () => await conditionalRelay, { desc: 'getConditionalRelay' });
+
+        const outer = reactive(
+          async () => {
+            outerCount++;
+            // Always consume alwaysUsedRelay first
+            const v1 = await getAlwaysRelay();
+            await sleep(10);
+            // Conditionally consume conditionalRelay after the await
+            if (useRelay.value) {
+              const v2 = await getConditionalRelay();
+              return v1! + v2!;
+            }
+            return v1!;
+          },
+          { desc: 'outer' },
+        );
+
+        // Initial run with useRelay = true
+        expect(outer).toHaveSignalValue(undefined);
+        await sleep(50);
+        expect(outer).toHaveSignalValue(142); // 100 + 42
+        expect(alwaysUsedRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(conditionalRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(outerCount).toBe(1);
+
+        // Now change useRelay to false - this dirties outer
+        useRelay.value = false;
+
+        await sleep(50);
+        expect(outer).toHaveSignalValue(100); // Only alwaysUsedRelay value now
+        expect(outerCount).toBe(2);
+
+        // alwaysUsedRelay should still be subscribed
+        expect(alwaysUsedRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+
+        // conditionalRelay should be unsubscribed AFTER the function fully resolved
+        // (not during the async execution)
+        await nextTick(); // Allow unsubscribe to be scheduled and executed
+        expect(conditionalRelay).toHaveCounts({ subscribe: 1, unsubscribe: 1 });
+      });
+
+      test('relay with async value setting consumed after await should not be prematurely unsubscribed', async () => {
+        // Test relay that sets its value asynchronously
+
+        let outerCount = 0;
+        const trigger = signal(1);
+        const relayValue = signal(100);
+
+        const asyncRelay = relay<number>(
+          state => {
+            const value = relayValue.value;
+            // Simulate async initialization
+            setTimeout(() => {
+              state.value = value;
+            }, 5);
+
+            return {
+              update: () => {
+                state.value = relayValue.value;
+              },
+              deactivate: () => {},
+            };
+          },
+          { desc: 'asyncRelay' },
+        );
+
+        // Wrap relay in a reactive function
+        const getAsyncRelay = reactive(async () => await asyncRelay, { desc: 'getAsyncRelay' });
+
+        const outer = reactive(
+          async () => {
+            outerCount++;
+            const t = trigger.value;
+            await sleep(10);
+            // Consume async relay after await
+            const v = await getAsyncRelay();
+            return t + v!;
+          },
+          { desc: 'outer' },
+        );
+
+        // Initial run
+        expect(outer).toHaveSignalValue(undefined);
+        await sleep(50);
+        expect(outer).toHaveSignalValue(101); // 1 + 100
+        expect(asyncRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+        expect(outerCount).toBe(1);
+
+        // Dirty outer by changing trigger
+        trigger.value = 2;
+
+        await sleep(50);
+        expect(outer).toHaveSignalValue(102); // 2 + 100
+        expect(outerCount).toBe(2);
+
+        // asyncRelay should NOT have been unsubscribed during the rerun
+        expect(asyncRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0 });
+
+        // Verify relay is still working by changing relayValue
+        relayValue.value = 200;
+        await sleep(50);
+        expect(outer).toHaveSignalValue(202); // 2 + 200
+        // Relay should have been updated, not unsubscribed/resubscribed
+        expect(asyncRelay).toHaveCounts({ subscribe: 1, unsubscribe: 0, update: 1 });
+      });
+    });
   });
 });


### PR DESCRIPTION
Say you have an async reactive function, and it has a few steps it has to do. When it reruns due to being DIRECTLY dirtied (e.g. something definitely changed, it's not a MaybeDirty), the function starts running again, and the following happens:

1. Reruns the signal
2. First part of the async function runs and consumes _some_ of the prior dependencies
3. Dependencies consumed _after_ the first await are unwatched and possibly garbage collected
4. They get re-created and re-added when the second part of the async function runs/continues

The desired behavior is that instead, we prune unused dependencies only _after_ the promise has resolved or rejected. 