### PR TITLE
query: Add API resilience features

### DIFF
--- a/.changeset/proud-jobs-attack.md
+++ b/.changeset/proud-jobs-attack.md
@@ -1,0 +1,8 @@
+---
+'@signalium/query': patch
+---
+
+Add API resilience features:
+- Array filtering for parse failures
+- Undefined fallback for optional types
+- `t.result` wrapper for handling and exposing parse errors directly

--- a/packages/query/src/EntityMap.ts
+++ b/packages/query/src/EntityMap.ts
@@ -138,6 +138,7 @@ export class EntityStore {
       });
     }
 
-    return createEntityProxy(record.key, record, shape, entityRelay, this.queryClient);
+    const warn = this.queryClient.getContext().log?.warn;
+    return createEntityProxy(record.key, record, shape, entityRelay, this.queryClient, warn);
   }
 }

--- a/packages/query/src/__tests__/api-resilience.test.ts
+++ b/packages/query/src/__tests__/api-resilience.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MemoryPersistentStore, SyncQueryStore } from '../stores/sync.js';
+import { QueryClient } from '../QueryClient.js';
+import { entity, t } from '../typeDefs.js';
+import { query } from '../query.js';
+import { createMockFetch, testWithClient } from './utils.js';
+import { parseValue, parseArrayValue } from '../proxy.js';
+
+/**
+ * API Resilience Tests
+ *
+ * Tests fault tolerance for additive API changes:
+ * - Array filtering for parse failures
+ * - Undefined fallback for optional types
+ * - Warning logger integration
+ */
+
+describe('API Resilience', () => {
+  let client: QueryClient;
+  let mockFetch: ReturnType<typeof createMockFetch>;
+  let warnLogger: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const store = new SyncQueryStore(new MemoryPersistentStore());
+    mockFetch = createMockFetch();
+    warnLogger = vi.fn();
+    client = new QueryClient(store, { fetch: mockFetch as any, log: { warn: warnLogger } });
+  });
+
+  afterEach(() => {
+    client?.destroy();
+  });
+
+  describe('Array Filtering', () => {
+    it('should filter out items with wrong primitive type', async () => {
+      mockFetch.get('/numbers', {
+        numbers: [1, 2, 'not a number', 4, true, 6],
+      });
+
+      await testWithClient(client, async () => {
+        const getNumbers = query(() => ({
+          path: '/numbers',
+          response: { numbers: t.array(t.number) },
+        }));
+
+        const relay = getNumbers();
+        const result = await relay;
+
+        // Should have filtered out 'not a number' and true
+        expect(result.numbers).toEqual([1, 2, 4, 6]);
+        expect(warnLogger).toHaveBeenCalled();
+      });
+    });
+
+    it('should filter out items with unknown enum value', async () => {
+      const Status = t.enum('active', 'inactive', 'pending');
+
+      mockFetch.get('/statuses', {
+        statuses: ['active', 'unknown_status', 'inactive', 'new_status', 'pending'],
+      });
+
+      await testWithClient(client, async () => {
+        const getStatuses = query(() => ({
+          path: '/statuses',
+          response: { statuses: t.array(Status) },
+        }));
+
+        const relay = getStatuses();
+        const result = await relay;
+
+        // Should have filtered out 'unknown_status' and 'new_status'
+        expect(result.statuses).toEqual(['active', 'inactive', 'pending']);
+        expect(warnLogger).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should filter out items with unknown typename in union', async () => {
+      const TextPost = entity(() => ({
+        __typename: t.typename('TextPost'),
+        id: t.id,
+        content: t.string,
+      }));
+
+      const ImagePost = entity(() => ({
+        __typename: t.typename('ImagePost'),
+        id: t.id,
+        url: t.string,
+      }));
+
+      const PostUnion = t.union(TextPost, ImagePost);
+
+      mockFetch.get('/posts', {
+        posts: [
+          { __typename: 'TextPost', id: '1', content: 'Hello' },
+          { __typename: 'VideoPost', id: '2', videoUrl: '/video.mp4' }, // Unknown type
+          { __typename: 'ImagePost', id: '3', url: '/img.jpg' },
+          { __typename: 'AudioPost', id: '4', audioUrl: '/audio.mp3' }, // Unknown type
+        ],
+      });
+
+      await testWithClient(client, async () => {
+        const getPosts = query(() => ({
+          path: '/posts',
+          response: { posts: t.array(PostUnion) },
+        }));
+
+        const relay = getPosts();
+        const result = await relay;
+
+        // Should have filtered out VideoPost and AudioPost
+        expect(result.posts).toHaveLength(2);
+        expect(result.posts[0].__typename).toBe('TextPost');
+        expect(result.posts[1].__typename).toBe('ImagePost');
+        expect(warnLogger).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should filter out items with invalid date format', async () => {
+      mockFetch.get('/dates', {
+        dates: ['2024-01-15', 'not-a-date', '2024-06-20', 'invalid'],
+      });
+
+      await testWithClient(client, async () => {
+        const getDates = query(() => ({
+          path: '/dates',
+          response: { dates: t.array(t.format('date')) },
+        }));
+
+        const relay = getDates();
+        const result = await relay;
+
+        // Should have filtered out 'not-a-date' and 'invalid'
+        expect(result.dates).toHaveLength(2);
+        expect(result.dates[0]).toBeInstanceOf(Date);
+        expect(result.dates[1]).toBeInstanceOf(Date);
+        expect(warnLogger).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should handle nested arrays with filtering at each level', async () => {
+      mockFetch.get('/nested', {
+        matrix: [
+          [1, 2, 'bad', 4],
+          ['all', 'bad', 'values'],
+          [5, 6, 7],
+        ],
+      });
+
+      await testWithClient(client, async () => {
+        const getNested = query(() => ({
+          path: '/nested',
+          response: { matrix: t.array(t.array(t.number)) },
+        }));
+
+        const relay = getNested();
+        const result = await relay;
+
+        // Inner arrays should have invalid items filtered
+        expect(result.matrix).toEqual([[1, 2, 4], [], [5, 6, 7]]);
+      });
+    });
+
+    it('should return empty array when all items are filtered', async () => {
+      mockFetch.get('/numbers', {
+        numbers: ['a', 'b', 'c'],
+      });
+
+      await testWithClient(client, async () => {
+        const getNumbers = query(() => ({
+          path: '/numbers',
+          response: { numbers: t.array(t.number) },
+        }));
+
+        const relay = getNumbers();
+        const result = await relay;
+
+        expect(result.numbers).toEqual([]);
+        expect(warnLogger).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    it('should filter entities with missing required ID', async () => {
+      const User = entity(() => ({
+        __typename: t.typename('User'),
+        id: t.id,
+        name: t.string,
+      }));
+
+      mockFetch.get('/users', {
+        users: [
+          { __typename: 'User', id: 1, name: 'Alice' },
+          { __typename: 'User', name: 'Missing ID' }, // No id field
+          { __typename: 'User', id: 3, name: 'Charlie' },
+        ],
+      });
+
+      await testWithClient(client, async () => {
+        const getUsers = query(() => ({
+          path: '/users',
+          response: { users: t.array(User) },
+        }));
+
+        const relay = getUsers();
+        const result = await relay;
+
+        // Should have filtered out the user without id
+        expect(result.users).toHaveLength(2);
+        expect(result.users[0].name).toBe('Alice');
+        expect(result.users[1].name).toBe('Charlie');
+        expect(warnLogger).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Undefined Fallback', () => {
+    it('should return undefined for optional field with invalid enum', () => {
+      const OptionalStatus = t.optional(t.enum('active', 'inactive'));
+
+      const result = parseValue('unknown_status', OptionalStatus, 'test.status', false, warnLogger);
+
+      expect(result).toBeUndefined();
+      expect(warnLogger).toHaveBeenCalledWith(
+        'Invalid value for optional type, defaulting to undefined',
+        expect.objectContaining({ value: 'unknown_status', path: 'test.status' }),
+      );
+    });
+
+    it('should return undefined for optional field with wrong type', () => {
+      const OptionalNumber = t.optional(t.number);
+
+      const result = parseValue('not a number', OptionalNumber, 'test.count', false, warnLogger);
+
+      expect(result).toBeUndefined();
+      expect(warnLogger).toHaveBeenCalled();
+    });
+
+    it('should return undefined for nullish field with invalid value', () => {
+      const NullishString = t.nullish(t.string);
+
+      const result = parseValue(12345, NullishString, 'test.name', false, warnLogger);
+
+      expect(result).toBeUndefined();
+      expect(warnLogger).toHaveBeenCalled();
+    });
+
+    it('should still throw for required field with invalid value', () => {
+      const RequiredNumber = t.number;
+
+      expect(() => {
+        parseValue('not a number', RequiredNumber, 'test.count');
+      }).toThrow(/Validation error/);
+    });
+
+    it('should still throw for required enum with invalid value', () => {
+      const RequiredStatus = t.enum('active', 'inactive');
+
+      expect(() => {
+        parseValue('unknown', RequiredStatus, 'test.status');
+      }).toThrow(/Validation error/);
+    });
+
+    it('should return undefined for optional field with invalid date format', () => {
+      const OptionalDate = t.optional(t.format('date'));
+
+      const result = parseValue('not-a-date', OptionalDate, 'test.date', false, warnLogger);
+
+      expect(result).toBeUndefined();
+      expect(warnLogger).toHaveBeenCalledWith(
+        'Invalid formatted value for optional type, defaulting to undefined',
+        expect.objectContaining({ path: 'test.date' }),
+      );
+    });
+
+    it('should work with optional fields in queries', async () => {
+      mockFetch.get('/item', {
+        name: 'Test',
+        status: 'unknown_new_status', // Unknown enum value
+        count: 'not a number', // Wrong type
+      });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: {
+            name: t.string,
+            status: t.optional(t.enum('active', 'inactive')),
+            count: t.optional(t.number),
+          },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.name).toBe('Test');
+        expect(result.status).toBeUndefined();
+        expect(result.count).toBeUndefined();
+        expect(warnLogger).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('Warning Logger', () => {
+    it('should receive correct context for filtered array items', async () => {
+      mockFetch.get('/numbers', {
+        numbers: [1, 'bad', 3],
+      });
+
+      await testWithClient(client, async () => {
+        const getNumbers = query(() => ({
+          path: '/numbers',
+          response: { numbers: t.array(t.number) },
+        }));
+
+        const relay = getNumbers();
+        await relay;
+
+        expect(warnLogger).toHaveBeenCalledWith(
+          'Failed to parse array item, filtering out',
+          expect.objectContaining({
+            index: 1,
+            value: 'bad',
+            error: expect.any(String),
+          }),
+        );
+      });
+    });
+
+    it('should receive correct context for undefined fallbacks', () => {
+      const OptionalNumber = t.optional(t.number);
+
+      parseValue('bad', OptionalNumber, 'my.path', false, warnLogger);
+
+      expect(warnLogger).toHaveBeenCalledWith(
+        'Invalid value for optional type, defaulting to undefined',
+        expect.objectContaining({
+          value: 'bad',
+          path: 'my.path',
+        }),
+      );
+    });
+
+    it('should not log when no warn logger is configured', async () => {
+      // Create a new client without a warn logger
+      const storeNoWarn = new SyncQueryStore(new MemoryPersistentStore());
+      const clientNoWarn = new QueryClient(storeNoWarn, { fetch: mockFetch as any });
+
+      mockFetch.get('/numbers', {
+        numbers: [1, 'bad', 3],
+      });
+
+      try {
+        await testWithClient(clientNoWarn, async () => {
+          const getNumbers = query(() => ({
+            path: '/numbers',
+            response: { numbers: t.array(t.number) },
+          }));
+
+          const relay = getNumbers();
+          const result = await relay;
+
+          // Should still filter, just not log
+          expect(result.numbers).toEqual([1, 3]);
+          expect(warnLogger).not.toHaveBeenCalled();
+        });
+      } finally {
+        clientNoWarn.destroy();
+      }
+    });
+  });
+
+  describe('Non-Array Errors Still Throw', () => {
+    it('should throw for required field in object with invalid value', async () => {
+      mockFetch.get('/item', {
+        count: 'not a number',
+      });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { count: t.number },
+        }));
+
+        const relay = getItem();
+
+        await expect(relay).rejects.toThrow(/Validation error/);
+      });
+    });
+
+    it('should throw for required enum in object with unknown value', async () => {
+      mockFetch.get('/item', {
+        status: 'unknown',
+      });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { status: t.enum('active', 'inactive') },
+        }));
+
+        const relay = getItem();
+
+        await expect(relay).rejects.toThrow(/Validation error/);
+      });
+    });
+  });
+});

--- a/packages/query/src/__tests__/entity-system.test.ts
+++ b/packages/query/src/__tests__/entity-system.test.ts
@@ -995,7 +995,7 @@ describe('Entity System', () => {
       });
     });
 
-    it('should throw error when union data omits typename', async () => {
+    it('should filter out union items that omit typename in arrays', async () => {
       const TextPost = entity(() => ({
         __typename: t.typename('TextPost'),
         id: t.id,
@@ -1010,7 +1010,7 @@ describe('Entity System', () => {
 
       const PostUnion = t.union(TextPost, ImagePost);
 
-      // Data without __typename - should fail for unions
+      // Data without __typename - should be filtered out in arrays (resilient parsing)
       mockFetch.get('/posts', {
         posts: [{ id: '1', content: 'Hello' }],
       });
@@ -1024,8 +1024,10 @@ describe('Entity System', () => {
         }));
 
         const relay = getPosts();
+        const result = await relay;
 
-        await expect(relay).rejects.toThrow(/typename.*required.*union/i);
+        // Item without typename should be filtered out, resulting in empty array
+        expect(result.posts).toEqual([]);
       });
     });
 

--- a/packages/query/src/__tests__/parse-result.test.ts
+++ b/packages/query/src/__tests__/parse-result.test.ts
@@ -1,0 +1,532 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { MemoryPersistentStore, SyncQueryStore } from '../stores/sync.js';
+import { QueryClient } from '../QueryClient.js';
+import { entity, t } from '../typeDefs.js';
+import { query } from '../query.js';
+import { createMockFetch, testWithClient } from './utils.js';
+import { parseValue } from '../proxy.js';
+import { ParseError, ParseResult, ParseSuccess } from '../types.js';
+
+/**
+ * t.result() Tests
+ *
+ * Tests for type-safe parse result wrapping:
+ * - Returns { success: true, value } on successful parse
+ * - Returns { success: false, error } on parse failure
+ * - Works with primitives, enums, entities, and nested types
+ */
+
+describe('t.result()', () => {
+  let client: QueryClient;
+  let mockFetch: ReturnType<typeof createMockFetch>;
+
+  beforeEach(() => {
+    const store = new SyncQueryStore(new MemoryPersistentStore());
+    mockFetch = createMockFetch();
+    // No warn logger - suppress warnings in tests
+    client = new QueryClient(store, { fetch: mockFetch as any });
+  });
+
+  afterEach(() => {
+    client?.destroy();
+  });
+
+  describe('Primitive Types', () => {
+    it('should return success for valid number', async () => {
+      mockFetch.get('/item', { value: 42 });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { value: t.result(t.number) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.value).toEqual({ success: true, value: 42 });
+      });
+    });
+
+    it('should return failure for number with string value', async () => {
+      mockFetch.get('/item', { value: 'not a number' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { value: t.result(t.number) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.value.success).toBe(false);
+        expect((result.value as ParseError).error).toBeInstanceOf(Error);
+      });
+    });
+
+    it('should return success for valid string', async () => {
+      mockFetch.get('/item', { value: 'hello' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { value: t.result(t.string) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.value).toEqual({ success: true, value: 'hello' });
+      });
+    });
+
+    it('should return success for valid boolean', async () => {
+      mockFetch.get('/item', { value: true });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { value: t.result(t.boolean) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.value).toEqual({ success: true, value: true });
+      });
+    });
+  });
+
+  describe('Enum Types', () => {
+    it('should return success for valid enum value', async () => {
+      const Status = t.enum('active', 'inactive', 'pending');
+
+      mockFetch.get('/item', { status: 'active' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { status: t.result(Status) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.status).toEqual({ success: true, value: 'active' });
+      });
+    });
+
+    it('should return failure for unknown enum value', async () => {
+      const Status = t.enum('active', 'inactive', 'pending');
+
+      mockFetch.get('/item', { status: 'unknown_status' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { status: t.result(Status) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.status.success).toBe(false);
+        expect((result.status as ParseError).error).toBeInstanceOf(Error);
+      });
+    });
+  });
+
+  describe('Array with parseResult', () => {
+    it('should wrap each item in array individually', async () => {
+      mockFetch.get('/items', {
+        items: [1, 'not a number', 3, null, 5],
+      });
+
+      await testWithClient(client, async () => {
+        const getItems = query(() => ({
+          path: '/items',
+          response: { items: t.array(t.result(t.number)) },
+        }));
+
+        const relay = getItems();
+        const result = await relay;
+
+        // Each item should be individually wrapped
+        expect(result.items).toHaveLength(5);
+        expect(result.items[0]).toEqual({ success: true, value: 1 });
+        expect(result.items[1].success).toBe(false);
+        expect(result.items[2]).toEqual({ success: true, value: 3 });
+        expect(result.items[3].success).toBe(false);
+        expect(result.items[4]).toEqual({ success: true, value: 5 });
+      });
+    });
+
+    it('should work with enum arrays', async () => {
+      const Status = t.enum('active', 'inactive');
+
+      mockFetch.get('/statuses', {
+        statuses: ['active', 'unknown', 'inactive', 'new_status'],
+      });
+
+      await testWithClient(client, async () => {
+        const getStatuses = query(() => ({
+          path: '/statuses',
+          response: { statuses: t.array(t.result(Status)) },
+        }));
+
+        const relay = getStatuses();
+        const result = await relay;
+
+        expect(result.statuses).toHaveLength(4);
+        expect(result.statuses[0]).toEqual({ success: true, value: 'active' });
+        expect(result.statuses[1].success).toBe(false);
+        expect(result.statuses[2]).toEqual({ success: true, value: 'inactive' });
+        expect(result.statuses[3].success).toBe(false);
+      });
+    });
+  });
+
+  describe('Entity Types', () => {
+    const UserEntity = entity(() => ({
+      __typename: t.typename('User'),
+      id: t.id,
+      name: t.string,
+      email: t.string,
+    }));
+
+    it('should return success with entity proxy for valid entity', async () => {
+      mockFetch.get('/user', {
+        user: { __typename: 'User', id: '1', name: 'Alice', email: 'alice@example.com' },
+      });
+
+      await testWithClient(client, async () => {
+        const getUser = query(() => ({
+          path: '/user',
+          response: { user: t.result(UserEntity) },
+        }));
+
+        const relay = getUser();
+        const result = await relay;
+
+        expect(result.user.success).toBe(true);
+        expect((result.user as ParseSuccess<unknown>).value).toHaveProperty('name', 'Alice');
+        expect((result.user as ParseSuccess<unknown>).value).toHaveProperty('email', 'alice@example.com');
+      });
+    });
+
+    it('should return failure for entity missing id', async () => {
+      mockFetch.get('/user', {
+        user: { __typename: 'User', name: 'Bob', email: 'bob@example.com' },
+      });
+
+      await testWithClient(client, async () => {
+        const getUser = query(() => ({
+          path: '/user',
+          response: { user: t.result(UserEntity) },
+        }));
+
+        const relay = getUser();
+        const result = await relay;
+
+        expect(result.user.success).toBe(false);
+        expect((result.user as ParseError).error).toBeInstanceOf(Error);
+      });
+    });
+
+    it('should work with array of entities', async () => {
+      mockFetch.get('/users', {
+        users: [
+          { __typename: 'User', id: '1', name: 'Alice', email: 'alice@example.com' },
+          { __typename: 'User', name: 'Missing ID', email: 'no-id@example.com' },
+          { __typename: 'User', id: '2', name: 'Bob', email: 'bob@example.com' },
+        ],
+      });
+
+      await testWithClient(client, async () => {
+        const getUsers = query(() => ({
+          path: '/users',
+          response: { users: t.array(t.result(UserEntity)) },
+        }));
+
+        const relay = getUsers();
+        const result = await relay;
+
+        expect(result.users).toHaveLength(3);
+        expect(result.users[0].success).toBe(true);
+        expect(result.users[1].success).toBe(false);
+        expect(result.users[2].success).toBe(true);
+      });
+    });
+  });
+
+  describe('Union Types in parseResult', () => {
+    const DogEntity = entity(() => ({
+      __typename: t.typename('Dog'),
+      id: t.id,
+      breed: t.string,
+    }));
+
+    const CatEntity = entity(() => ({
+      __typename: t.typename('Cat'),
+      id: t.id,
+      color: t.string,
+    }));
+
+    const PetUnion = t.union(DogEntity, CatEntity);
+
+    it('should return success for valid union member', async () => {
+      mockFetch.get('/pet', {
+        pet: { __typename: 'Dog', id: '1', breed: 'Golden Retriever' },
+      });
+
+      await testWithClient(client, async () => {
+        const getPet = query(() => ({
+          path: '/pet',
+          response: { pet: t.result(PetUnion) },
+        }));
+
+        const relay = getPet();
+        const result = await relay;
+
+        expect(result.pet.success).toBe(true);
+        expect((result.pet as ParseSuccess<unknown>).value).toHaveProperty('breed', 'Golden Retriever');
+      });
+    });
+
+    it('should return failure for unknown typename in union', async () => {
+      mockFetch.get('/pet', {
+        pet: { __typename: 'Bird', id: '1', species: 'Parrot' },
+      });
+
+      await testWithClient(client, async () => {
+        const getPet = query(() => ({
+          path: '/pet',
+          response: { pet: t.result(PetUnion) },
+        }));
+
+        const relay = getPet();
+        const result = await relay;
+
+        expect(result.pet.success).toBe(false);
+        expect((result.pet as ParseError).error.message).toContain('Unknown typename');
+      });
+    });
+  });
+
+  describe('Formatted Types', () => {
+    it('should return success for valid date format', async () => {
+      mockFetch.get('/item', { date: '2024-01-15T10:30:00.000Z' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { date: t.result(t.format('date-time')) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.date.success).toBe(true);
+        expect((result.date as ParseSuccess<Date>).value).toBeInstanceOf(Date);
+      });
+    });
+
+    it('should return failure for invalid date format', async () => {
+      mockFetch.get('/item', { date: 'not-a-date' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { date: t.result(t.format('date-time')) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        expect(result.date.success).toBe(false);
+        expect((result.date as ParseError).error).toBeInstanceOf(Error);
+      });
+    });
+  });
+
+  describe('Nested parseResult', () => {
+    it('should handle parseResult inside object', async () => {
+      mockFetch.get('/data', {
+        data: {
+          name: 'Test',
+          value: 42,
+          optional: 'not a number',
+        },
+      });
+
+      await testWithClient(client, async () => {
+        const getData = query(() => ({
+          path: '/data',
+          response: {
+            data: t.object({
+              name: t.string,
+              value: t.number,
+              optional: t.result(t.number),
+            }),
+          },
+        }));
+
+        const relay = getData();
+        const result = await relay;
+
+        expect(result.data.name).toBe('Test');
+        expect(result.data.value).toBe(42);
+        expect(result.data.optional.success).toBe(false);
+      });
+    });
+
+    it('should handle nested object inside parseResult', async () => {
+      mockFetch.get('/data', {
+        wrapper: {
+          inner: {
+            value: 'hello',
+          },
+        },
+      });
+
+      await testWithClient(client, async () => {
+        const getData = query(() => ({
+          path: '/data',
+          response: {
+            wrapper: t.result(
+              t.object({
+                inner: t.object({
+                  value: t.string,
+                }),
+              }),
+            ),
+          },
+        }));
+
+        const relay = getData();
+        const result = await relay;
+
+        expect(result.wrapper.success).toBe(true);
+        expect((result.wrapper as ParseSuccess<{ inner: { value: string } }>).value.inner.value).toBe('hello');
+      });
+    });
+  });
+
+  describe('Direct parseValue usage', () => {
+    it('should work with parseValue directly', () => {
+      const numberResult = t.result(t.number);
+
+      const success = parseValue(42, numberResult, 'test');
+      expect(success).toEqual({ success: true, value: 42 });
+
+      const failure = parseValue('not a number', numberResult, 'test');
+      expect((failure as ParseResult<number>).success).toBe(false);
+    });
+  });
+
+  describe('Override fallback behavior', () => {
+    it('should return error for t.result(t.optional(t.number)) with invalid value', async () => {
+      mockFetch.get('/item', { value: 'not a number' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { value: t.result(t.optional(t.number)) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        // Should NOT fall back to undefined - should return error
+        expect(result.value.success).toBe(false);
+        expect((result.value as ParseError).error).toBeInstanceOf(Error);
+      });
+    });
+
+    it('should return error for t.result(t.optional(t.format)) with invalid value', async () => {
+      mockFetch.get('/item', { date: 'not-a-date' });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { date: t.result(t.optional(t.format('date-time'))) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        // Should NOT fall back to undefined - should return error
+        expect(result.date.success).toBe(false);
+        expect((result.date as ParseError).error).toBeInstanceOf(Error);
+      });
+    });
+
+    it('should include errors in array with t.result items', async () => {
+      mockFetch.get('/items', {
+        items: [1, 'invalid', 3],
+      });
+
+      await testWithClient(client, async () => {
+        const getItems = query(() => ({
+          path: '/items',
+          response: { items: t.array(t.result(t.number)) },
+        }));
+
+        const relay = getItems();
+        const result = await relay;
+
+        // All items should be present (not filtered)
+        expect(result.items).toHaveLength(3);
+        expect(result.items[0]).toEqual({ success: true, value: 1 });
+        expect(result.items[1].success).toBe(false);
+        expect(result.items[2]).toEqual({ success: true, value: 3 });
+      });
+    });
+
+    it('should return success with undefined for t.result(t.optional(t.number)) when value is undefined', async () => {
+      mockFetch.get('/item', { value: undefined });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { value: t.result(t.optional(t.number)) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        // undefined IS a valid value for optional - should succeed
+        expect(result.value.success).toBe(true);
+        expect((result.value as ParseSuccess<number | undefined>).value).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Type safety', () => {
+    it('should have correct types for success case', async () => {
+      mockFetch.get('/item', { value: 42 });
+
+      await testWithClient(client, async () => {
+        const getItem = query(() => ({
+          path: '/item',
+          response: { value: t.result(t.number) },
+        }));
+
+        const relay = getItem();
+        const result = await relay;
+
+        // TypeScript should infer this correctly
+        if (result.value.success) {
+          // value should be number
+          const num: number = result.value.value;
+          expect(typeof num).toBe('number');
+        } else {
+          // error should be Error
+          const err: Error = result.value.error;
+          expect(err).toBeInstanceOf(Error);
+        }
+      });
+    });
+  });
+});

--- a/packages/query/src/typeDefs.ts
+++ b/packages/query/src/typeDefs.ts
@@ -11,6 +11,7 @@ import {
   Mask,
   ObjectDef,
   ObjectShape,
+  ParseResultDef,
   RECORD_KEY,
   RecordDef,
   TypeDef,
@@ -30,6 +31,7 @@ const enum ComplexTypeDefKind {
   ARRAY = 3,
   RECORD = 4,
   ENTITY = 5,
+  PARSE_RESULT = 6,
 }
 
 export class ValidatorDef<T> {
@@ -111,7 +113,8 @@ export class ValidatorDef<T> {
           this._shape = reifyUnionShape(this, this._shape as ComplexTypeDef[]);
           break;
         case ComplexTypeDefKind.ARRAY:
-        case ComplexTypeDefKind.RECORD: {
+        case ComplexTypeDefKind.RECORD:
+        case ComplexTypeDefKind.PARSE_RESULT: {
           const shape = this._shape;
 
           let shapeKey;
@@ -324,6 +327,14 @@ export function defineArray<T extends TypeDef>(shape: T): ArrayDef<T> {
 
 export function defineRecord<T extends TypeDef>(shape: T): RecordDef<T> {
   return new ValidatorDef(ComplexTypeDefKind.RECORD, Mask.RECORD | Mask.OBJECT, shape) as unknown as RecordDef<T>;
+}
+
+export function defineParseResult<T extends TypeDef>(innerType: T): ParseResultDef<T> {
+  return new ValidatorDef(
+    ComplexTypeDefKind.PARSE_RESULT,
+    Mask.PARSE_RESULT,
+    innerType,
+  ) as unknown as ParseResultDef<T>;
 }
 
 export function defineObject<T extends ObjectShape>(shape: T): ObjectDef<T> {
@@ -770,7 +781,8 @@ export function entity<T extends ObjectShape, M extends EntityMethods = {}>(
   }
 
   if (config) {
-    def._entityConfig = config;
+    // `any` because of infinite recursive type issue
+    (def as any)._entityConfig = config;
   }
 
   return def as unknown as EntityDef<T, M>;
@@ -794,4 +806,5 @@ export const t: APITypes = {
   nullish: defineNullish,
   optional: defineOptional,
   nullable: defineNullable,
+  result: defineParseResult,
 };


### PR DESCRIPTION
Add API resilience features:
- Array filtering for parse failures
- Undefined fallback for optional types
- `t.result` wrapper for handling and exposing parse errors directly
