### PR TITLE
query: Ensure entities have a unique prototype

### DIFF
--- a/.changeset/empty-lizards-sing.md
+++ b/.changeset/empty-lizards-sing.md
@@ -1,0 +1,5 @@
+---
+'@signalium/query': patch
+---
+
+Ensure entities have a unique prototype

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -11,3 +11,4 @@ export type { Draft } from './utils.js';
 export { NetworkManager, NoOpNetworkManager, defaultNetworkManager, NetworkManagerContext } from './NetworkManager.js';
 export { MemoryEvictionManager, NoOpMemoryEvictionManager } from './MemoryEvictionManager.js';
 export { RefetchManager, NoOpRefetchManager } from './RefetchManager.js';
+export { Entity } from './proxy.js';

--- a/packages/query/src/proxy.ts
+++ b/packages/query/src/proxy.ts
@@ -24,6 +24,10 @@ const isArray = Array.isArray;
 
 const PROXY_ID = new WeakMap();
 
+// Placeholder class used as the prototype for entity proxies.
+// This prevents them from being treated as plain objects in utilities like `hashValue()`.
+export class Entity {}
+
 function parseUnionValue(
   valueType: number,
   value: Record<string, unknown> | unknown[],
@@ -322,6 +326,10 @@ export function createEntityProxy(
   let proxy: Record<string, unknown>;
 
   const handler: ProxyHandler<object> = {
+    getPrototypeOf() {
+      return Entity.prototype;
+    },
+
     get(target, prop) {
       // Handle toJSON for serialization
       if (prop === 'toJSON') {


### PR DESCRIPTION
Currently, entity results are being fully hashed when passed to reactive functions. Providing a different prototype should prevent this from happening.