### PR TITLE
fix: Switch back to WeakRefs and Native GC

### DIFF
--- a/.changeset/better-cows-joke.md
+++ b/.changeset/better-cows-joke.md
@@ -1,0 +1,5 @@
+---
+'signalium': patch
+---
+
+Switch back to native GC for signals

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -88,10 +88,10 @@
     }
   },
   "scripts": {
-    "dev": "vitest dev",
-    "dev:unit": "vitest dev --project unit",
-    "dev:transform": "vitest dev --project transform",
-    "dev:react": "vitest dev --project react",
+    "dev": "node --expose-gc ./node_modules/vitest/vitest.mjs dev",
+    "dev:unit": "node --expose-gc ./node_modules/vitest/vitest.mjs dev --project unit",
+    "dev:transform": "node --expose-gc ./node_modules/vitest/vitest.mjs dev --project transform",
+    "dev:react": "node --expose-gc ./node_modules/vitest/vitest.mjs dev --project react",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
     "test:transform": "vitest run --project transform",

--- a/packages/query/src/__tests__/gc-time.test.ts
+++ b/packages/query/src/__tests__/gc-time.test.ts
@@ -63,6 +63,7 @@ describe('GC Time', () => {
       });
 
       await sleep(200);
+      (global as any).gc();
 
       await testWithClient(client, async () => {
         const relay = getItem({ id: '1' });

--- a/packages/query/src/__tests__/stream.test.ts
+++ b/packages/query/src/__tests__/stream.test.ts
@@ -746,6 +746,7 @@ describe('Stream Query', () => {
         // Wait for memory eviction (gcTime + eviction interval buffer)
         // With evictionMultiplier of 0.01, the eviction interval is 600ms
         await new Promise(resolve => setTimeout(resolve, 700));
+        (global as any).gc();
 
         // Second subscription after gc - should NOT have cached data in memory
         await testWithClient(testClient, async () => {

--- a/packages/signalium/package.json
+++ b/packages/signalium/package.json
@@ -117,8 +117,8 @@
     }
   },
   "scripts": {
-    "dev": "vitest dev",
-    "dev:unit": "vitest dev --project unit",
+    "dev": "node --expose-gc ./node_modules/vitest/vitest.mjs dev",
+    "dev:unit": "node --expose-gc ./node_modules/vitest/vitest.mjs dev --project unit",
     "dev:transform": "vitest dev --project transform",
     "dev:react": "vitest dev --project react",
     "test": "vitest run",

--- a/packages/signalium/src/__tests__/gc.test.ts
+++ b/packages/signalium/src/__tests__/gc.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { reactive, context, withContexts, watcher, signal } from '../index.js';
+import { reactive, context, withContexts, watcher, signal, Watcher } from '../index.js';
 import { SignalScope, getGlobalScope, clearGlobalContexts } from '../internals/contexts.js';
 import { nextTick, sleep } from './utils/async.js';
 
 // Helper to access private properties for testing
-const getSignalsMap = (scope: SignalScope) => {
-  return (scope as any).signals as Map<number, any>;
+const getSignalsCount = (scope: SignalScope = getGlobalScope()) => {
+  const signals = (scope as any).signals as Map<number, WeakRef<any>>;
+
+  return Array.from(signals.values()).filter(ref => ref.deref() !== undefined).length;
 };
 
-const getGCCandidates = (scope: SignalScope) => {
-  return (scope as any).gcCandidates as Set<any>;
+const runIsolatedAsync = async (fn: () => Promise<void>) => {
+  await fn();
+
+  // sleep to ensure that everything has been cleaned up
+  await sleep(10);
+
+  // force a GC
+  global.gc();
 };
 
 describe('Garbage Collection', () => {
@@ -20,25 +28,28 @@ describe('Garbage Collection', () => {
   it('should automatically garbage collect unwatched signals', async () => {
     const testSignal = reactive(() => 42);
 
-    const w = watcher(() => testSignal());
+    await runIsolatedAsync(async () => {
+      const w = watcher(() => testSignal());
 
-    // Watch the signal
-    const unwatch = w.addListener(() => {
-      testSignal();
+      // Watch the signal
+      const unwatch = w.addListener(() => {
+        testSignal();
+      });
+
+      await sleep(10);
+
+      // force a GC to ensure that the signal is not garbage collected
+      global.gc();
+
+      // Signal should be in the scope
+      expect(getSignalsCount()).toBe(1);
+
+      // Unwatch the signal
+      unwatch();
     });
 
-    await nextTick();
-
-    // Signal should be in the scope
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
-
-    // Unwatch the signal
-    unwatch();
-
-    await sleep(50);
-
     // Signal should be garbage collected
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
+    expect(getSignalsCount()).toBe(0);
   });
 
   it('should not garbage collect signals that are still being watched', async () => {
@@ -47,20 +58,22 @@ describe('Garbage Collection', () => {
 
     const w = watcher(() => watchedSignal());
 
-    // Watch the signal but don't unwatch
-    w.addListener(() => {
-      watchedSignal();
+    await runIsolatedAsync(async () => {
+      // Watch the signal but don't unwatch
+      w.addListener(() => {
+        watchedSignal();
+      });
+
+      await nextTick();
+
+      // Signal should be in the scope
+      expect(getSignalsCount()).toBe(1);
+
+      await sleep(50);
     });
 
-    await nextTick();
-
-    // Signal should be in the scope
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
-
-    await sleep(50);
-
     // Signal should still be in the scope because it's being watched
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
+    expect(getSignalsCount()).toBe(1);
   });
 
   it('should handle context-scoped signals correctly', async () => {
@@ -91,40 +104,162 @@ describe('Garbage Collection', () => {
     await sleep(50);
 
     // Signal should be garbage collected from the context scope
-    expect(getSignalsMap(contextScope).size).toBe(0);
+    expect(getSignalsCount(contextScope)).toBe(0);
   });
 
-  it('should remove signal from GC candidates if watched again', async () => {
-    // Create a signal
-    const signal = reactive(() => 'rewatch');
+  it('propagates unwatching to dependencies and tears them down without GC', async () => {
+    // Track how many times our reactive function reruns.
+    let evalCount = 0;
 
-    const w = watcher(() => signal());
+    const source = signal(1);
 
-    // Watch and unwatch
-    const unwatch = w.addListener(() => {});
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    w.value;
+    // Direct consumers of a signal always rerun when it changes. So we
+    // need a _second_ reactive function to observe caching behavior.
+    const mid1 = reactive(() => source.value + 1);
 
-    await nextTick();
+    // This second function increments the counter. It will _not_ rerun
+    // if `mid1`'s output hasn't changed.
+    const mid2 = reactive(() => {
+      evalCount++;
+      return mid1() + 1;
+    });
 
-    // Signal should be in the scope
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
+    await runIsolatedAsync(async () => {
+      const top = watcher(() => mid2());
 
-    unwatch();
-    await nextTick();
+      let unwatchTop = top.addListener(() => {});
 
-    // Signal should be in GC candidates
-    expect(getGCCandidates(getGlobalScope()).size).toBe(2);
+      // Wait for initial activation.
+      await nextTick();
 
-    // Watch again
-    w.addListener(() => {});
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    w.value;
+      expect(evalCount).toBe(1);
+      expect(getSignalsCount()).toBe(2);
 
-    await nextTick();
+      // Verify the counter works by changing source.
+      source.value = 2;
+      await nextTick();
 
-    // Signal should be removed from GC candidates
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
-    expect(getGCCandidates(getGlobalScope()).size).toBe(0);
+      expect(evalCount).toBe(2);
+      expect(getSignalsCount()).toBe(2);
+
+      // Suspend the Watcher — function should not rerun.
+      unwatchTop();
+      await nextTick();
+
+      expect(evalCount).toBe(2);
+      expect(getSignalsCount()).toBe(2);
+
+      // Change source while suspended — still no rerun.
+      source.value = 3;
+      await nextTick();
+
+      expect(evalCount).toBe(2);
+      expect(getSignalsCount()).toBe(2);
+
+      // Reset source to 2 and resume. The _output_ of `mid1` is still
+      // 2 + 1 = 3, unchanged. So `mid2` should NOT rerun if cached.
+      //
+      // If `mid2` had been GC'd, it would have to be recreated, and the
+      // counter would increment.
+      source.value = 2;
+      unwatchTop = top.addListener(() => {});
+      await nextTick();
+
+      expect(evalCount).toBe(2);
+      expect(getSignalsCount()).toBe(2);
+
+      // Fully unwatch — counter should remain unchanged.
+      unwatchTop();
+    });
+
+    expect(evalCount).toBe(2);
+    expect(getSignalsCount()).toBe(0);
+  });
+
+  it('shared dependency stays active until all consumers are garbage collected', async () => {
+    // Track how many times mid2 re-evaluates.
+    let evalCount = 0;
+
+    const source = signal(1);
+    const mid1 = reactive(() => source.value + 1);
+    const mid2 = reactive(() => {
+      evalCount++;
+      return mid1() + 1;
+    });
+
+    await runIsolatedAsync(async () => {
+      // Two watchers share the same dependency chain.
+      const topA = watcher(() => mid2());
+      const topB = watcher(() => mid2());
+
+      const unwatchA = topA.addListener(() => {});
+      const unwatchB = topB.addListener(() => {});
+
+      await nextTick();
+
+      // Both watchers share mid2 — it evaluates once.
+      expect(evalCount).toBe(1);
+      expect(getSignalsCount()).toBe(2);
+
+      // Suspend only A — mid2 stays active because B is still watching.
+      unwatchA();
+      source.value = 2;
+      await nextTick();
+
+      // mid2 re-evaluates because B is still active.
+      expect(evalCount).toBe(2);
+      expect(getSignalsCount()).toBe(2);
+
+      // Suspend B — mid2 is now fully suspended.
+      unwatchB();
+      source.value = 3;
+      await nextTick();
+
+      // No re-evaluation while fully suspended.
+      expect(evalCount).toBe(2);
+      expect(getSignalsCount()).toBe(2);
+
+      // Unwatch both — signals should be cleaned up.
+      unwatchA();
+      unwatchB();
+    });
+
+    expect(evalCount).toBe(2);
+    expect(getSignalsCount()).toBe(0);
+  });
+
+  it('does not leak state across repeated watch-unwatch cycles', async () => {
+    let evalCount = 0;
+
+    const source = signal(1);
+    const mid1 = reactive(() => source.value + 1);
+    const mid2 = reactive(() => {
+      evalCount++;
+      return mid1() + 1;
+    });
+
+    for (let i = 0; i < 15; i++) {
+      await runIsolatedAsync(async () => {
+        // Watcher needs to be defined within the loop to
+        // ensure that the signals will be garbage collected,
+        // otherwise the closure holds onto them
+        const top = watcher(() => mid2());
+
+        let unwatchTop = top.addListener(() => {});
+        await nextTick();
+
+        expect(getSignalsCount()).toBe(2);
+
+        // Suspend and unwatch.
+        unwatchTop();
+      });
+
+      expect(getSignalsCount()).toBe(0);
+    }
+
+    // After many cycles, all signals should be properly cleaned up.
+    await sleep(50);
+
+    expect(getSignalsCount()).toBe(0);
   });
 });

--- a/packages/signalium/src/__tests__/reactive-async.test.ts
+++ b/packages/signalium/src/__tests__/reactive-async.test.ts
@@ -662,7 +662,7 @@ describe('async computeds', () => {
       let dep2Count = 0;
       let outerCount = 0;
 
-      const useDep1 = signal(true);
+      const useDep2 = signal(true);
       const state1 = signal(1);
       const state2 = signal(2);
 
@@ -689,7 +689,7 @@ describe('async computeds', () => {
           const val1 = await dep1();
           await sleep(10);
           // Conditionally consume dep2 after the await
-          if (useDep1.value) {
+          if (useDep2.value) {
             const val2 = await dep2();
             return val1 + val2;
           }
@@ -698,7 +698,7 @@ describe('async computeds', () => {
         { desc: 'outer' },
       );
 
-      // Initial run with useDep1 = true
+      // Initial run with useDep2 = true
       const r1 = outer();
       await sleep(20);
       expect(r1.value).toBe(210);
@@ -706,8 +706,8 @@ describe('async computeds', () => {
       expect(dep2Count).toBe(1);
       expect(outerCount).toBe(1);
 
-      // Now change useDep1 to false - this dirties outer
-      useDep1.value = false;
+      // Now change useDep2 to false - this dirties outer
+      useDep2.value = false;
 
       const r2 = outer();
       expect(r2.isPending).toBe(true);
@@ -721,13 +721,16 @@ describe('async computeds', () => {
       // (it wasn't consumed this time and should have been disconnected)
       expect(dep2Count).toBe(1);
 
-      // Now change useDep1 to true again
-      useDep1.value = true;
+      // Now change useDep2 to true again
+      useDep2.value = true;
 
       const r3 = outer();
       expect(r3.isPending).toBe(true);
 
-      await sleep(20);
+      // Force garbage collection
+      global.gc();
+
+      await sleep(100);
       expect(r3.isResolved).toBe(true);
       expect(r3.value).toBe(210); // 2*10 + 2*100
 

--- a/packages/signalium/src/__tests__/reactive-immediate-read-sequential.test.ts
+++ b/packages/signalium/src/__tests__/reactive-immediate-read-sequential.test.ts
@@ -1,7 +1,163 @@
 import { describe, expect, test } from 'vitest';
 import { signal, watcher } from 'signalium';
 import { reactive } from './utils/instrumented-hooks.js';
-import { nextTick } from './utils/async.js';
+import { nextTick, sleep } from './utils/async.js';
+
+// ─── Debug utility: log the full signal dependency tree ───
+
+const STATE_NAMES: Record<number, string> = {
+  0: 'Clean',
+  1: 'Pending',
+  2: 'Dirty',
+  3: 'MaybeDirty',
+  4: 'PendingDirty',
+};
+
+function logSignalTree(promiseOrSignal: any, label?: string, stateSignals?: Record<string, any>) {
+  const visited = new Set<any>();
+  const lines: string[] = [];
+
+  function line(indent: number, text: string) {
+    lines.push('  '.repeat(indent) + text);
+  }
+
+  function fmtPromise(p: any, indent: number) {
+    const f: number = p['_flags'];
+    const pending = !!(f & 1);
+    const rejected = !!(f & (1 << 1));
+    const resolved = !!(f & (1 << 2));
+    const ready = !!(f & (1 << 3));
+
+    line(indent, `[ReactivePromise]  pending=${pending}  resolved=${resolved}  ready=${ready}  rejected=${rejected}`);
+    line(indent, `  value: ${JSON.stringify(p['_value'])}`);
+    line(indent, `  _updatedCount: ${p['_updatedCount']}`);
+
+    const awaitSubs: Map<any, any> = p['_awaitSubs'];
+    line(indent, `  _awaitSubs (${awaitSubs.size}):`);
+    for (const [ref, edge] of awaitSubs) {
+      const sig = ref.deref?.();
+      const desc = sig?.def?.desc ?? sig?.id ?? '??';
+      line(
+        indent,
+        `    <- ${desc}  (edge type=${edge.type === 0 ? 'Signal' : 'Promise'}, updatedAt=${edge.updatedAt}, consumedAt=${edge.consumedAt})`,
+      );
+    }
+
+    const pendingList: any[] = p['_pending'];
+    line(indent, `  _pending (${pendingList.length}):`);
+    for (const item of pendingList) {
+      const sig = item.ref?.deref?.();
+      const desc = sig?.def?.desc ?? sig?.id ?? '(no ref)';
+      line(indent, `    <- ${desc}`);
+    }
+  }
+
+  function fmtSignal(sig: any, indent: number) {
+    if (visited.has(sig)) {
+      line(indent, `[circular -> ${sig.def?.desc ?? sig.id}]`);
+      return;
+    }
+    visited.add(sig);
+
+    const desc = sig.def?.desc ?? `signal#${sig.id}`;
+    const stateNum: number = sig['_state'];
+    const state = STATE_NAMES[stateNum] ?? `?(${stateNum})`;
+
+    line(indent, `[${desc}]  id=${sig.id}`);
+    // line(indent, `  state: ${state}`);
+    // line(
+    //   indent,
+    //   `  updatedCount=${sig.updatedCount}  computedCount=${sig.computedCount}  watchCount=${sig.watchCount}`,
+    // );
+
+    // ── value ──
+    // const val = sig['_value'];
+    // if (val != null && typeof val === 'object' && '_awaitSubs' in val) {
+    //   fmtPromise(val, indent + 1);
+    // } else {
+    //   line(indent, `  value: ${JSON.stringify(val)}`);
+    // }
+
+    // ── dirty head chain ──
+    // let dirtyEdge = sig.dirtyHead;
+    // if (dirtyEdge) {
+    //   line(indent, `  dirtyHead chain:`);
+    //   while (dirtyEdge) {
+    //     const etype = dirtyEdge.type === 0 ? 'Signal' : 'Promise';
+    //     let depDesc: string;
+    //     if (dirtyEdge.type === 0) {
+    //       depDesc = dirtyEdge.dep?.def?.desc ?? dirtyEdge.dep?.id ?? '??';
+    //     } else {
+    //       const pSig = dirtyEdge.dep?.['_signal'];
+    //       depDesc = `promise(of ${pSig?.def?.desc ?? pSig?.id ?? '??'})`;
+    //     }
+    //     line(
+    //       indent,
+    //       `    [${etype}] ${depDesc}  (updatedAt=${dirtyEdge.updatedAt}, consumedAt=${dirtyEdge.consumedAt}, ord=${dirtyEdge.ord})`,
+    //     );
+    //     dirtyEdge = dirtyEdge.nextDirty;
+    //   }
+    // }
+
+    // ── deps (what this signal consumes) ──
+    const deps: Map<any, any> = sig.deps;
+    // line(indent, `  deps (${deps.size}):`);
+    for (const [dep, edge] of deps) {
+      const etype = edge.type === 0 ? 'Signal' : 'Promise';
+      const depDesc = dep.def?.desc ?? dep.id;
+      // line(
+      //   indent,
+      //   `    [${etype}] -> ${depDesc}  (updatedAt=${edge.updatedAt}, consumedAt=${edge.consumedAt}, ord=${edge.ord})`,
+      // );
+      fmtSignal(dep, indent + 2);
+    }
+
+    // ── subs (who consumes this signal) ──
+    // const subs: Map<any, any> = sig.subs;
+    // line(indent, `  subs (${subs.size}):`);
+    // for (const [ref] of subs) {
+    //   const sub = ref.deref?.();
+    //   const subDesc = sub?.def?.desc ?? sub?.id ?? '(gc)';
+    //   line(indent, `    <- ${subDesc}`);
+    // }
+  }
+
+  // ── entry point: navigate from ReactivePromise → its backing ReactiveSignal ──
+  let rootSignal: any;
+  if (promiseOrSignal != null && typeof promiseOrSignal === 'object' && '_awaitSubs' in promiseOrSignal) {
+    rootSignal = promiseOrSignal['_signal'];
+    if (!rootSignal) {
+      lines.push('(ReactivePromise has no backing _signal)');
+    }
+  } else {
+    rootSignal = promiseOrSignal;
+  }
+
+  if (rootSignal) {
+    fmtSignal(rootSignal, 0);
+  }
+
+  // ── optional: state signals (from signal()) ──
+  // if (stateSignals) {
+  //   lines.push('');
+  //   for (const [name, ss] of Object.entries(stateSignals)) {
+  //     line(0, `[StateSignal: ${name}]  (desc=${ss['_desc']}, id=${ss['_id']})`);
+  //     line(0, `  value: ${JSON.stringify(ss['_value'])}`);
+  //     const subs: Map<any, any> = ss['_subs'];
+  //     line(0, `  subs (${subs.size}):`);
+  //     for (const [ref, consumedAt] of subs) {
+  //       const sig = ref.deref?.();
+  //       const desc = sig?.def?.desc ?? sig?.id ?? '(gc)';
+  //       line(0, `    <- ${desc}  (consumedAt=${consumedAt})`);
+  //     }
+  //   }
+  // }
+
+  const header = label ? `\n━━━ ${label} ━━━` : '\n━━━ Signal Tree ━━━';
+  console.log(header + '\n' + lines.join('\n') + '\n');
+}
+
+// ─── Tests ───
 
 describe('reactive async immediate read after sequential writes', () => {
   test.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])(
@@ -54,11 +210,14 @@ describe('reactive async immediate read after sequential writes', () => {
       // 2) second write
       write('dog');
       items = await getOutermost();
+      expect(items).toContain('cat');
       expect(items).toContain('dog');
 
       // 3) third write — this has been observed to intermittently fail
       write('fish');
       items = await getOutermost();
+      expect(items).toContain('cat');
+      expect(items).toContain('dog');
       expect(items).toContain('fish');
     },
   );

--- a/packages/signalium/src/internals/contexts.ts
+++ b/packages/signalium/src/internals/contexts.ts
@@ -1,6 +1,5 @@
 import { ReactiveSignal, ReactiveDefinition, createReactiveSignal } from './reactive.js';
 import { hashReactiveFn, hashValue } from './utils/hash.js';
-import { scheduleGcSweep } from './scheduling.js';
 import { getCurrentConsumer } from './consumer.js';
 import { Context } from '../types.js';
 
@@ -67,7 +66,7 @@ export class SignalScope {
 
   private contexts: Record<symbol, unknown>;
   private children = new Map<number, SignalScope>();
-  private signals = new Map<number, ReactiveSignal<any, any>>();
+  private signals = new Map<number, WeakRef<ReactiveSignal<any, any>>>();
   private gcCandidates = new Set<ReactiveSignal<any, any>>();
 
   setContexts(contexts: [ContextImpl<unknown>, unknown][]) {
@@ -104,48 +103,14 @@ export class SignalScope {
   get<T, Args extends unknown[]>(def: ReactiveDefinition<T, Args>, args: Args): ReactiveSignal<T, Args> {
     const paramKey = def.paramKey?.(...args);
     const key = hashReactiveFn(def.compute, paramKey ? [paramKey] : args);
-    let signal = this.signals.get(key) as ReactiveSignal<T, Args> | undefined;
+    let signal = this.signals.get(key)?.deref() as ReactiveSignal<T, Args> | undefined;
 
     if (signal === undefined) {
       signal = createReactiveSignal(def, args, key, this);
-      this.signals.set(key, signal);
+      this.signals.set(key, new WeakRef(signal));
     }
 
     return signal;
-  }
-
-  markForGc(signal: ReactiveSignal<any, any>) {
-    if (!this.gcCandidates.has(signal)) {
-      this.gcCandidates.add(signal);
-      scheduleGcSweep(this);
-    }
-  }
-
-  removeFromGc(signal: ReactiveSignal<any, any>) {
-    this.gcCandidates.delete(signal);
-
-    const { key } = signal;
-
-    // if the signal has a key, add it back to the signals map so we can re-use it
-    if (key) {
-      this.signals.set(key, signal);
-    }
-  }
-
-  forceGc(signal: ReactiveSignal<any, any>) {
-    this.signals.delete(signal.key!);
-  }
-
-  sweepGc() {
-    const signals = this.signals;
-
-    for (const signal of this.gcCandidates) {
-      if (signal.watchCount === 0) {
-        signals.delete(signal.key!);
-      }
-    }
-
-    this.gcCandidates = new Set();
   }
 }
 
@@ -218,5 +183,5 @@ export const getScopeOwner = (obj: object): SignalScope => {
 
 export function forceGc(_signal: object) {
   const signal = _signal as ReactiveSignal<any, any>;
-  signal.scope?.forceGc(signal);
+  // signal.scope?.forceGc(signal);
 }

--- a/packages/signalium/src/internals/scheduling.ts
+++ b/packages/signalium/src/internals/scheduling.ts
@@ -68,19 +68,19 @@ export const scheduleTracer = (tracer: Tracer) => {
   }
 };
 
-export const scheduleGcSweep = (scope: SignalScope) => {
-  PENDING_GC.add(scope);
+// export const scheduleGcSweep = (scope: SignalScope) => {
+//   PENDING_GC.add(scope);
 
-  if (PENDING_GC.size > 1) return;
+//   if (PENDING_GC.size > 1) return;
 
-  scheduleIdleCallback(() => {
-    for (const scope of PENDING_GC) {
-      scope.sweepGc();
-    }
+//   scheduleIdleCallback(() => {
+//     for (const scope of PENDING_GC) {
+//       scope.sweepGc();
+//     }
 
-    PENDING_GC.clear();
-  });
-};
+//     PENDING_GC.clear();
+//   });
+// };
 
 const flushWatchers = async () => {
   const flush = currentFlush!;

--- a/packages/signalium/src/internals/watch.ts
+++ b/packages/signalium/src/internals/watch.ts
@@ -11,7 +11,7 @@ export function watchSignal(signal: ReactiveSignal<any, any>): void {
   if (watchCount > 0) return;
 
   // If signal is being watched again, remove from GC candidates and add back to scope
-  signal.scope?.removeFromGc(signal);
+  // signal.scope?.removeFromGc(signal);
 
   for (const dep of signal.deps.keys()) {
     watchSignal(dep);
@@ -43,7 +43,7 @@ export function unwatchSignal(signal: ReactiveSignal<any, any>, count = 1) {
   }
 
   // If watchCount is now zero, mark the signal for GC
-  if (newWatchCount === 0 && signal.scope) {
-    signal.scope.markForGc(signal);
-  }
+  // if (newWatchCount === 0 && signal.scope) {
+  //   signal.scope.markForGc(signal);
+  // }
 }

--- a/packages/signalium/src/react/__tests__/suspend-signals-value-preservation.test.tsx
+++ b/packages/signalium/src/react/__tests__/suspend-signals-value-preservation.test.tsx
@@ -1,0 +1,257 @@
+import { describe, expect, test } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { signal, reactive, relay } from 'signalium';
+import { useReactive, SuspendSignalsProvider } from '../index.js';
+import React, { useState } from 'react';
+import { userEvent } from '@vitest/browser/context';
+import { sleep } from '../../__tests__/utils/async.js';
+import { createRenderCounter } from './utils.js';
+import component from '../component.js';
+
+describe('React > Suspend Signals > Value Preservation', () => {
+  test('async reactive value is preserved across suspend/resume cycle', async () => {
+    const input = signal('Hello');
+
+    const derived = reactive(async () => {
+      const v = input.value;
+      await sleep(50);
+      return `${v}, World`;
+    });
+
+    /**
+     * Renders the resolved value of an async reactive, or "Loading..." while pending.
+     * Tracks whether the value was ever lost (went back to pending/undefined) after
+     * initially resolving — this is the bug we're testing.
+     */
+    let valueLostAfterResolve = false;
+    let hasResolved = false;
+
+    function Inner(): React.ReactNode {
+      const d = useReactive(derived);
+
+      if (d.isResolved && d.value !== undefined) {
+        hasResolved = true;
+      }
+
+      // Detect if value is lost after initial resolution
+      if (hasResolved && d.isPending && d.value === undefined) {
+        valueLostAfterResolve = true;
+      }
+
+      return <div data-testid="content">{d.isPending && !d.value ? 'Loading...' : d.value}</div>;
+    }
+
+    function Wrapper(): React.ReactNode {
+      const [suspended, setSuspended] = useState(false);
+
+      return (
+        <div>
+          <SuspendSignalsProvider value={suspended}>
+            <Inner />
+          </SuspendSignalsProvider>
+          <button onClick={() => setSuspended(s => !s)}>Toggle</button>
+        </div>
+      );
+    }
+
+    const { getByText, getByTestId } = render(<Wrapper />);
+
+    // Wait for initial async resolution
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+
+    // Suspend signals (simulate tab blur)
+    await userEvent.click(getByText('Toggle'));
+    await sleep(50);
+
+    // Value should still be visible while suspended
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+
+    // Resume signals (simulate tab focus)
+    await userEvent.click(getByText('Toggle'));
+
+    // BUG: After resuming, the value should still be "Hello, World" immediately.
+    // Instead, the signal goes through a pending state with undefined value because
+    // unwatchSignal destroys the ReactivePromise's resolved state.
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+    expect(valueLostAfterResolve).toBe(false);
+  });
+
+  test('relay value is preserved across suspend/resume cycle', async () => {
+    const input = signal('Hello');
+
+    const derived = reactive(() => {
+      return relay<string>(state => {
+        const v = input.value;
+        const run = async () => {
+          await sleep(50);
+          return `${v}, World`;
+        };
+
+        state.setPromise(run());
+      });
+    });
+
+    /**
+     * Same as above, but for relay-based async values.
+     * Tests that relay deactivation/reactivation during suspension
+     * does not cause the resolved value to be lost.
+     */
+    let valueLostAfterResolve = false;
+    let hasResolved = false;
+
+    function Inner(): React.ReactNode {
+      const d = useReactive(derived);
+
+      if (d.isResolved && d.value !== undefined) {
+        hasResolved = true;
+      }
+
+      if (hasResolved && d.isPending && d.value === undefined) {
+        valueLostAfterResolve = true;
+      }
+
+      return <div data-testid="content">{d.isPending && !d.value ? 'Loading...' : d.value}</div>;
+    }
+
+    function Wrapper(): React.ReactNode {
+      const [suspended, setSuspended] = useState(false);
+
+      return (
+        <div>
+          <SuspendSignalsProvider value={suspended}>
+            <Inner />
+          </SuspendSignalsProvider>
+          <button onClick={() => setSuspended(s => !s)}>Toggle</button>
+        </div>
+      );
+    }
+
+    const { getByText, getByTestId } = render(<Wrapper />);
+
+    // Wait for initial resolution
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+
+    // Suspend signals
+    await userEvent.click(getByText('Toggle'));
+    await sleep(50);
+
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+
+    // Resume signals
+    await userEvent.click(getByText('Toggle'));
+
+    // Value should be preserved — no pending flash
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+    expect(valueLostAfterResolve).toBe(false);
+  });
+
+  test('rapid suspend/resume cycles do not cause value loss', async () => {
+    const input = signal('Hello');
+
+    const derived = reactive(async () => {
+      const v = input.value;
+      await sleep(50);
+      return `${v}, World`;
+    });
+
+    let valueLostCount = 0;
+    let hasResolved = false;
+
+    function Inner(): React.ReactNode {
+      const d = useReactive(derived);
+
+      if (d.isResolved && d.value !== undefined) {
+        hasResolved = true;
+      }
+
+      if (hasResolved && d.isPending && d.value === undefined) {
+        valueLostCount++;
+      }
+
+      return <div data-testid="content">{d.isPending && !d.value ? 'Loading...' : d.value}</div>;
+    }
+
+    function Wrapper(): React.ReactNode {
+      const [suspended, setSuspended] = useState(false);
+
+      return (
+        <div>
+          <SuspendSignalsProvider value={suspended}>
+            <Inner />
+          </SuspendSignalsProvider>
+          <button data-testid="toggle" onClick={() => setSuspended(s => !s)}>
+            Toggle
+          </button>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<Wrapper />);
+
+    // Wait for initial resolution
+    await expect.element(getByTestId('content')).toHaveTextContent('Loading...');
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+
+    // Rapidly toggle suspend/resume 5 times (simulating quick tab switches)
+    for (let i = 0; i < 5; i++) {
+      await userEvent.click(getByTestId('toggle')); // suspend
+      await sleep(10);
+      await userEvent.click(getByTestId('toggle')); // resume
+      await sleep(10);
+    }
+
+    // After all cycles, value should still be present
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+    expect(valueLostCount).toBe(0);
+  });
+
+  test('unmounting while suspended does not retain stale suspend state on remount', async () => {
+    const input = signal('Hello');
+
+    const derived = reactive(async () => {
+      const v = input.value;
+      await sleep(20);
+      return `${v}, World`;
+    });
+
+    function Inner(): React.ReactNode {
+      const d = useReactive(derived);
+      return <div data-testid="content">{d.isPending && !d.value ? 'Loading...' : d.value}</div>;
+    }
+
+    function Wrapper(): React.ReactNode {
+      const [suspended, setSuspended] = useState(false);
+      const [mounted, setMounted] = useState(true);
+
+      return (
+        <div>
+          <SuspendSignalsProvider value={suspended}>{mounted ? <Inner /> : null}</SuspendSignalsProvider>
+          <button data-testid="toggle-suspend" onClick={() => setSuspended(s => !s)}>
+            Toggle Suspend
+          </button>
+          <button data-testid="toggle-mounted" onClick={() => setMounted(s => !s)}>
+            Toggle Mounted
+          </button>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<Wrapper />);
+
+    await expect.element(getByTestId('content')).toHaveTextContent('Loading...');
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+
+    // Suspend and unmount while suspended.
+    await userEvent.click(getByTestId('toggle-suspend'));
+    await userEvent.click(getByTestId('toggle-mounted'));
+    await sleep(20);
+
+    // Resume and remount. If suspend state leaked, this can stay stale/pending forever.
+    await userEvent.click(getByTestId('toggle-suspend'));
+    await userEvent.click(getByTestId('toggle-mounted'));
+
+    await expect.element(getByTestId('content')).toHaveTextContent('Hello, World');
+  });
+});


### PR DESCRIPTION
We were seeing some issues with values being dropped too early when suspended, and/or being _duplicated_ when reactivated. This change should help fix some of these issues by ensuring that if a signal is still referenced, even if it's not actively being watched, it will not be garbage collected.