### PR TITLE
fix(fetchium): Export TypeDefSymbol for declaration emit

### DIFF
--- a/.changeset/export-typedef-symbol.md
+++ b/.changeset/export-typedef-symbol.md
@@ -1,0 +1,5 @@
+---
+"fetchium": patch
+---
+
+Export `TypeDefSymbol` so downstream consumers can emit `.d.ts` files without TS4029 errors when using `TypeDef<T>` in public type positions, such as when extending `Entity`.

--- a/packages/fetchium/src/types.ts
+++ b/packages/fetchium/src/types.ts
@@ -123,7 +123,7 @@ export interface CaseInsensitiveEnumSet<T extends string | boolean | number> ext
 // Public Branded TypeDef
 // ================================
 
-declare const TypeDefSymbol: unique symbol;
+export declare const TypeDefSymbol: unique symbol;
 
 /**
  * Branded phantom type representing a type definition in the public API.


### PR DESCRIPTION
## Summary

- Export `TypeDefSymbol` from `fetchium/src/types.ts` so that downstream consumers can emit `.d.ts` files without TS4029 errors.

## Context

`TypeDef<T>` is branded with `TypeDefSymbol`, but the symbol wasn't exported. When a consumer extends fetchium's `Entity` class and enables `declaration: true` in their tsconfig, TypeScript's declaration emitter needs to reference the symbol in the generated `.d.ts` output and fails because it can't be named. This is a standard pattern for branded/opaque types (Zod, Effect, etc. all export their branding symbols for the same reason).

## Test plan

- [x] Verified `tsc --emitDeclarationOnly` succeeds and `TypeDefSymbol` appears in the generated `.d.ts` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)