### PR TITLE
feat(signalium): Add async component support with Suspense integration

### DIFF
--- a/.changeset/bumpy-lines-start.md
+++ b/.changeset/bumpy-lines-start.md
@@ -1,0 +1,6 @@
+---
+'signalium': minor
+'@signalium/docs': patch
+---
+
+Add support for async components and Suspense

--- a/SIGNALIUM_TRANSFORMS.md
+++ b/SIGNALIUM_TRANSFORMS.md
@@ -8,7 +8,7 @@ Source: `packages/signalium/src/transform/`
 
 ### 1. Async transform (`async.ts`)
 
-Rewrites `async` functions passed to `reactive()`, `relay()`, `task()`, `watcher()`, etc. into generator functions. This allows the reactive runtime to pause/resume execution at `await` points, inserting promise-edge dependencies into the reactive graph.
+Rewrites `async` functions passed to `reactive()`, `relay()`, `task()`, `watcher()`, `component()`, etc. into generator functions. This allows the reactive runtime to pause/resume execution at `await` points, inserting promise-edge dependencies into the reactive graph. For `component()`, this enables async components that integrate with React's `<Suspense>` boundaries.
 
 **Before:**
 

--- a/docs/src/app/api/signalium/react/page.md
+++ b/docs/src/app/api/signalium/react/page.md
@@ -12,16 +12,25 @@ nextjs:
 
 ```ts
 export default function component<Props extends object>(
-  fn: (props: Props) => React.ReactNode | React.ReactNode[] | null,
+  fn: (
+    props: Props,
+  ) =>
+    | React.ReactNode
+    | React.ReactNode[]
+    | null
+    | Promise<React.ReactNode | React.ReactNode[] | null>,
 ): (props: Props) => React.ReactElement;
 ```
 
 Create a reactive component from a pure function. Inside the function, read `Signal` values and other reactive sources directly. Re-renders are scheduled automatically when dependencies change.
 
+The function can be `async` — when it is, the component integrates with React's `<Suspense>` boundaries. The Suspense fallback is shown until the first `await` resolves, then the component renders normally. Hooks (like `useSignal`) work in the synchronous portion before the first `await`. Requires the Signalium Babel preset.
+
 ```tsx
 import { component, useSignal } from 'signalium/react';
 import { reactive, type Signal } from 'signalium';
 
+// Sync component
 const fullName = reactive(
   (first: Signal<string>, last: Signal<string>) =>
     `${first.value} ${last.value}`,
@@ -39,11 +48,25 @@ const Name = component(() => {
     </div>
   );
 });
+
+// Async component (requires Suspense boundary)
+const fetchUser = reactive(async (id: string) => {
+  const res = await fetch(`/api/users/${id}`);
+  return res.json();
+});
+
+const UserCard = component(async () => {
+  const user = await fetchUser('1');
+  return <div>{user.name}</div>;
+});
+
+// Usage:
+// <Suspense fallback={<Loading />}><UserCard /></Suspense>
 ```
 
-| Parameter | Type                          | Description     |
-| --------- | ----------------------------- | --------------- |
-| fn        | `(props: Props) => ReactNode` | Render function |
+| Parameter | Type                                                | Description                     |
+| --------- | --------------------------------------------------- | ------------------------------- |
+| fn        | `(props: Props) => ReactNode \| Promise<ReactNode>` | Render function (sync or async) |
 
 ### useSignal
 

--- a/docs/src/app/core/react/page.md
+++ b/docs/src/app/core/react/page.md
@@ -239,11 +239,7 @@ const DataComponent = component(() => {
 });
 ```
 
-However, there are two important things to note:
-
-1. Signalium components, like React client-components, _cannot_ be async themselves. This means that if you want to use a Reactive Promise in a component, you must use the state properties directly and handle all of the possible states.
-
-2. Reactive Promises are always the same object instance, even when their value changes. This means that `React.memo` will not trigger a re-render when the promise's value updates:
+However, there is one important thing to note. Reactive Promises are always the same object instance, even when their value changes. This means that `React.memo` will not trigger a re-render when the promise's value updates:
 
 ```tsx
 import { memo } from 'react';
@@ -263,6 +259,51 @@ function Parent() {
   return <MemoizedComponent value={data.value} />;
 }
 ```
+
+### Async Components
+
+Components can also be `async` — Signalium will integrate with React's `Suspense` automatically. While the async work is in-flight, a parent `<Suspense>` boundary shows the fallback. Once the result resolves, the component renders.
+
+```tsx
+import { component, useSignal } from 'signalium/react';
+import { reactive } from 'signalium';
+import { Suspense } from 'react';
+
+const fetchUser = reactive(async (id: string) => {
+  const res = await fetch(`/api/users/${id}`);
+  return res.json();
+});
+
+const UserProfile = component(async () => {
+  const userId = useSignal('1');
+  const user = await fetchUser(userId.value);
+
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <button onClick={() => (userId.value = '2')}>Next user</button>
+    </div>
+  );
+});
+
+function App() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <UserProfile />
+    </Suspense>
+  );
+}
+```
+
+Hooks like `useSignal` work normally in async components — they run in the synchronous portion _before_ the first `await`. When a dependency changes (either a hook or a signal), the component re-executes, re-running hooks and restarting the async work.
+
+{% callout type="note" title="Babel transform required" %}
+Async components require the Signalium Babel preset (`signalium/transform`). The preset transforms the `async` function into a generator, which allows the reactive runtime to pause and resume execution at `await` points. Without the transform, the component will not integrate with Suspense correctly.
+{% /callout %}
+
+{% callout type="warning" title="Error handling" %}
+Errors thrown after an `await` in an async component are captured on the underlying Reactive Promise (accessible via `error` and `isRejected` properties when using the promise directly). Error boundary integration for `component(async () => {...})` is not yet supported — for error-sensitive async work, use `reactive(async () => {...})` with explicit `isRejected` / `error` checks in a sync component wrapper.
+{% /callout %}
 
 ### Suspense and React Server Components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@changesets/cli": "^2.29.8",
-        "@types/react": "^18.3.12",
+        "@types/react": "^18.3.28",
         "eslint": "^9.15.0",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
@@ -29,7 +29,7 @@
     },
     "docs": {
       "name": "@signalium/docs",
-      "version": "0.0.39",
+      "version": "0.0.41",
       "license": "ISC",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.9.2",
@@ -56,7 +56,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-highlight-words": "^0.20.0",
-        "signalium": "2.2.3",
+        "signalium": "2.3.1",
         "simple-functional-loader": "^1.2.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.3.3"
@@ -3742,13 +3742,13 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-highlight-words": {
@@ -4775,9 +4775,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/de-indent": {
@@ -8778,7 +8778,7 @@
       }
     },
     "packages/fetchium": {
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -8790,7 +8790,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rollup-plugin-const-enum": "^1.1.4",
-        "signalium": "2.2.3",
+        "signalium": "2.3.1",
         "vite": "^7.1.2",
         "vite-plugin-babel": "^1.3.0",
         "vite-plugin-dts": "^4.5.4",
@@ -8870,7 +8870,7 @@
       }
     },
     "packages/signalium": {
-      "version": "2.2.3",
+      "version": "2.3.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "packageManager": "npm@8.5.0",
   "dependencies": {
     "@changesets/cli": "^2.29.8",
-    "@types/react": "^18.3.12",
+    "@types/react": "^18.3.28",
     "eslint": "^9.15.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",

--- a/packages/signalium/src/internals/async.ts
+++ b/packages/signalium/src/internals/async.ts
@@ -17,6 +17,7 @@ import { signal } from './signal.js';
 import { DEFAULT_EQUALS, equalsFrom } from './utils/equals.js';
 import { getCurrentConsumer } from './consumer.js';
 import { createCallback } from './callback.js';
+import { maybeAbortPromise } from './generators.js';
 import { getTracerProxy, TracerEventType } from './trace.js';
 
 function isAbortError(error: unknown): boolean {
@@ -409,6 +410,13 @@ export class ReactivePromiseImpl<T> implements IReactivePromise<T> {
   }
 
   async _setPromise(promise: Promise<T>) {
+    // Abort the previous generator-backed promise if it supports it, to prevent
+    // stale generators from continuing to run and tracking phantom dependencies.
+    const prev = this._promise;
+    if (prev !== undefined && prev !== promise) {
+      maybeAbortPromise(prev);
+    }
+
     // Store the current promise so we can check if it's the same promise in the
     // then handlers. If it's not the same promise, it means that the promise has
     // been recomputed and replaced, so we should not update state.
@@ -576,6 +584,12 @@ export class ReactivePromiseImpl<T> implements IReactivePromise<T> {
 
     return this._value;
   }
+
+  // No-op setter: React 19's Suspense thenable tracking sets .value on thrown
+  // thenables (fulfilledThenable.value = fulfilledValue). Without a setter, this
+  // throws a TypeError in strict mode since .value is a getter. The setter is
+  // intentionally ignored — _value set via _setValue remains the source of truth.
+  set value(_: T | undefined) {}
 
   get error() {
     this._consumeFlags(AsyncFlags.Error);

--- a/packages/signalium/src/internals/generators.ts
+++ b/packages/signalium/src/internals/generators.ts
@@ -4,6 +4,12 @@ import { getInternalCurrentScope, setCurrentScope, SignalScope } from './context
 import { ReactiveSignal } from './reactive.js';
 import { isPromise } from './utils/type-utils.js';
 
+const ABORT_MAP = new WeakMap<Promise<unknown>, () => void>();
+
+export function maybeAbortPromise(promise: Promise<unknown>): void {
+  ABORT_MAP.get(promise)?.();
+}
+
 export function generatorResultToPromiseWithConsumer<T>(
   generator: Generator<any, T>,
   savedConsumer: ReactiveSignal<any, any> | undefined,
@@ -14,8 +20,12 @@ export function generatorResultToPromiseWithConsumer<T>(
       : Promise.resolve(value);
   }
 
-  return new Promise((resolve, reject) => {
+  let aborted = false;
+
+  const promise: Promise<T> = new Promise((resolve, reject) => {
     function step(fn: (value: any) => IteratorResult<any, any>, value?: any) {
+      if (aborted) return;
+
       const prevConsumer = getCurrentConsumer();
 
       try {
@@ -46,6 +56,18 @@ export function generatorResultToPromiseWithConsumer<T>(
 
     step(nextFn);
   });
+
+  ABORT_MAP.set(promise, () => {
+    if (aborted) return;
+    aborted = true;
+    try {
+      generator.return(undefined as any);
+    } catch {
+      // ignore errors from generator cleanup
+    }
+  });
+
+  return promise;
 }
 
 export function generatorResultToPromiseWithScope<T, Args extends unknown[]>(

--- a/packages/signalium/src/react/__tests__/async-components.test.tsx
+++ b/packages/signalium/src/react/__tests__/async-components.test.tsx
@@ -1,0 +1,884 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { signal, reactive } from 'signalium';
+import { component, useSignal } from 'signalium/react';
+import React, { Suspense } from 'react';
+import { userEvent } from '@vitest/browser/context';
+import { sleep } from '../../__tests__/utils/async.js';
+
+describe('React > Async Components', () => {
+  test('basic Suspense: shows fallback then resolved content', async () => {
+    const AsyncComp = component(async () => {
+      await sleep(100);
+      return <div>Loaded</div>;
+    });
+
+    const { getByText } = render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <AsyncComp />
+      </Suspense>,
+    );
+
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByText('Loaded')).toBeInTheDocument();
+  });
+
+  test('reads reactive signals before await', async () => {
+    const name = signal('World');
+
+    const AsyncComp = component(async () => {
+      const n = name.value;
+      await sleep(100);
+      return <div>Hello, {n}</div>;
+    });
+
+    const { getByText } = render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <AsyncComp />
+      </Suspense>,
+    );
+
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByText('Hello, World')).toBeInTheDocument();
+
+    name.value = 'Universe';
+    await expect.element(getByText('Hello, Universe')).toBeInTheDocument();
+  });
+
+  test('hooks work before await', async () => {
+    const AsyncComp = component(async () => {
+      const count = useSignal(0);
+
+      await sleep(100);
+
+      return (
+        <div>
+          <span>Count: {count.value}</span>
+          <button onClick={() => count.value++}>Inc</button>
+        </div>
+      );
+    });
+
+    const { getByText } = render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <AsyncComp />
+      </Suspense>,
+    );
+
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByText('Count: 0')).toBeInTheDocument();
+  });
+
+  test('awaits reactive async functions', async () => {
+    const id = signal('a');
+
+    const fetchData = reactive(async (key: string) => {
+      await sleep(100);
+      return `data-${key}`;
+    });
+
+    const AsyncComp = component(async () => {
+      const result = await fetchData(id.value);
+      return <div>{result}</div>;
+    });
+
+    const { getByText } = render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <AsyncComp />
+      </Suspense>,
+    );
+
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByText('data-a')).toBeInTheDocument();
+
+    id.value = 'b';
+    await expect.element(getByText('data-b')).toBeInTheDocument();
+  });
+
+  test('updates when dep changes with new async value', async () => {
+    const id = signal('a');
+
+    const fetchData = reactive(async (key: string) => {
+      await sleep(100);
+      return `data-${key}`;
+    });
+
+    const AsyncComp = component(async () => {
+      const result = await fetchData(id.value);
+      return <div>{result}</div>;
+    });
+
+    const { getByText } = render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <AsyncComp />
+      </Suspense>,
+    );
+
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByText('data-a')).toBeInTheDocument();
+
+    id.value = 'b';
+    await expect.element(getByText('data-b')).toBeInTheDocument();
+  });
+
+  test('sync component still works after refactor', async () => {
+    const text = signal('Hello');
+
+    const SyncComp = component(() => <div>{text.value}</div>);
+
+    const { getByText } = render(<SyncComp />);
+
+    await expect.element(getByText('Hello')).toBeInTheDocument();
+
+    text.value = 'World';
+    await expect.element(getByText('World')).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // Post-settle single triggers
+  // =========================================================================
+
+  describe('post-settle triggers', () => {
+    test('useSignal triggers rerun after settle', async () => {
+      const AsyncComp = component(async () => {
+        const count = useSignal(0);
+        const val = count.value;
+
+        await sleep(50);
+
+        return (
+          <div>
+            <span>val:{val}</span>
+            <button onClick={() => count.value++}>bump</button>
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('val:0')).toBeInTheDocument();
+
+      await userEvent.click(getByText('bump'));
+      await expect.element(getByText('val:1')).toBeInTheDocument();
+
+      await userEvent.click(getByText('bump'));
+      await expect.element(getByText('val:2')).toBeInTheDocument();
+    });
+
+    test('external signal triggers rerun after settle', async () => {
+      const ext = signal('A');
+
+      const AsyncComp = component(async () => {
+        const v = ext.value;
+        await sleep(50);
+        return <div>ext:{v}</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('ext:A')).toBeInTheDocument();
+
+      ext.value = 'B';
+      await expect.element(getByText('ext:B')).toBeInTheDocument();
+
+      ext.value = 'C';
+      await expect.element(getByText('ext:C')).toBeInTheDocument();
+    });
+
+    test('useSignal and signal change simultaneously after settle', async () => {
+      const ext = signal('X');
+
+      const AsyncComp = component(async () => {
+        const local = useSignal(0);
+        const localVal = local.value;
+        const extVal = ext.value;
+
+        await sleep(50);
+
+        return (
+          <div>
+            <span>
+              combo:{localVal}-{extVal}
+            </span>
+            <button
+              onClick={() => {
+                local.value++;
+                ext.value = ext.value === 'X' ? 'Y' : 'X';
+              }}
+            >
+              both
+            </button>
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('combo:0-X')).toBeInTheDocument();
+
+      await userEvent.click(getByText('both'));
+      await expect.element(getByText('combo:1-Y')).toBeInTheDocument();
+
+      await userEvent.click(getByText('both'));
+      await expect.element(getByText('combo:2-X')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Mid-flight triggers (changes while initial load is pending)
+  // =========================================================================
+
+  describe('mid-flight triggers', () => {
+    test('signal change during initial Suspense resolves to latest value', async () => {
+      const ext = signal('first');
+
+      const AsyncComp = component(async () => {
+        const v = ext.value;
+        await sleep(100);
+        return <div>got:{v}</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+
+      // Change signal while the first await is still pending
+      await sleep(30);
+      ext.value = 'second';
+
+      await expect.element(getByText('got:second')).toBeInTheDocument();
+    });
+
+    test('rapid signal changes during initial Suspense settles to last value', async () => {
+      const ext = signal('a');
+
+      const AsyncComp = component(async () => {
+        const v = ext.value;
+        await sleep(80);
+        return <div>rapid:{v}</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+
+      // Fire several rapid updates while the component is still suspended
+      await sleep(10);
+      ext.value = 'b';
+      await sleep(10);
+      ext.value = 'c';
+      await sleep(10);
+      ext.value = 'd';
+
+      await expect.element(getByText('rapid:d')).toBeInTheDocument();
+    });
+
+    test('signal change from sibling during Suspense', async () => {
+      const shared = signal('init');
+
+      const AsyncComp = component(async () => {
+        const v = shared.value;
+        await sleep(100);
+        return <div>async:{v}</div>;
+      });
+
+      const Sibling = () => <button onClick={() => (shared.value = 'updated')}>update-from-sibling</button>;
+
+      const { getByText } = render(
+        <div>
+          <Sibling />
+          <Suspense fallback={<div>Loading...</div>}>
+            <AsyncComp />
+          </Suspense>
+        </div>,
+      );
+
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+
+      // Sibling triggers a shared signal change while async is pending
+      await userEvent.click(getByText('update-from-sibling'));
+
+      await expect.element(getByText('async:updated')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Rapid re-triggers after settle
+  // =========================================================================
+
+  describe('rapid re-triggers after settle', () => {
+    test('multiple rapid signal changes after settle shows last value', async () => {
+      const ext = signal('start');
+
+      const AsyncComp = component(async () => {
+        const v = ext.value;
+        await sleep(50);
+        return <div>v:{v}</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('v:start')).toBeInTheDocument();
+
+      // Rapid-fire changes
+      ext.value = 'a';
+      ext.value = 'b';
+      ext.value = 'c';
+      ext.value = 'final';
+
+      await expect.element(getByText('v:final')).toBeInTheDocument();
+    });
+
+    test('signal change while previous revalidation is in-flight skips intermediate', async () => {
+      const ext = signal('1');
+
+      const fetchData = reactive(async (key: string) => {
+        await sleep(80);
+        return `fetched-${key}`;
+      });
+
+      const AsyncComp = component(async () => {
+        const result = await fetchData(ext.value);
+        return <div>{result}</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('fetched-1')).toBeInTheDocument();
+
+      // Start a revalidation
+      ext.value = '2';
+
+      // Before it finishes (~80ms), change again
+      await sleep(20);
+      ext.value = '3';
+
+      // Should skip '2' and end up on '3'
+      await expect.element(getByText('fetched-3')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Mixed async and sync dependencies
+  // =========================================================================
+
+  describe('mixed dependencies', () => {
+    test('sync dep before await + async dep after await update independently', async () => {
+      const syncDep = signal('sync-A');
+      const asyncInput = signal('x');
+
+      const fetchData = reactive(async (key: string) => {
+        await sleep(60);
+        return `async-${key}`;
+      });
+
+      const AsyncComp = component(async () => {
+        const s = syncDep.value;
+        const a = await fetchData(asyncInput.value);
+        return (
+          <div>
+            mixed:{s}/{a}
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('mixed:sync-A/async-x')).toBeInTheDocument();
+
+      // Change only the sync dep
+      syncDep.value = 'sync-B';
+      await expect.element(getByText('mixed:sync-B/async-x')).toBeInTheDocument();
+
+      // Change only the async dep
+      asyncInput.value = 'y';
+      await expect.element(getByText('mixed:sync-B/async-y')).toBeInTheDocument();
+    });
+
+    test('useSignal + external signal + awaited reactive all update correctly', async () => {
+      const ext = signal('E');
+      const asyncInput = signal('1');
+
+      const fetchData = reactive(async (key: string) => {
+        await sleep(50);
+        return `f(${key})`;
+      });
+
+      const AsyncComp = component(async () => {
+        const local = useSignal('L');
+        const localVal = local.value;
+        const extVal = ext.value;
+        const asyncVal = await fetchData(asyncInput.value);
+
+        return (
+          <div>
+            <span>
+              triple:{localVal}/{extVal}/{asyncVal}
+            </span>
+            <button onClick={() => (local.value = 'L2')}>setLocal</button>
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('triple:L/E/f(1)')).toBeInTheDocument();
+
+      // Change useSignal via button
+      await userEvent.click(getByText('setLocal'));
+      await expect.element(getByText('triple:L2/E/f(1)')).toBeInTheDocument();
+
+      // Change external signal
+      ext.value = 'E2';
+      await expect.element(getByText('triple:L2/E2/f(1)')).toBeInTheDocument();
+
+      // Change async input
+      asyncInput.value = '2';
+      await expect.element(getByText('triple:L2/E2/f(2)')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Error handling
+  // =========================================================================
+
+  describe('error handling', () => {
+    test('async component error is captured on the ReactivePromise', async () => {
+      const shouldFail = signal(true);
+
+      const fetchData = reactive(async (fail: boolean) => {
+        await sleep(50);
+        if (fail) throw new Error('boom');
+        return 'ok';
+      });
+
+      // Use a sync component wrapper to observe the ReactivePromise state
+      // since error boundary integration with async component generators is
+      // not yet supported (the retry loop prevents errors from surfacing to
+      // React's ErrorBoundary).
+      const Wrapper = component(() => {
+        const result = fetchData(shouldFail.value);
+
+        if (result.isPending) return <div>Loading...</div>;
+        if (result.isRejected) return <div>error:{(result.error as Error).message}</div>;
+        return <div>ok:{result.value}</div>;
+      });
+
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { getByText } = render(<Wrapper />);
+
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+      await expect.element(getByText('error:boom')).toBeInTheDocument();
+
+      spy.mockRestore();
+    });
+
+    test('recovery after error when dep changes to non-throwing value', async () => {
+      const shouldFail = signal(true);
+
+      const fetchData = reactive(async (fail: boolean) => {
+        await sleep(50);
+        if (fail) throw new Error('oops');
+        return 'recovered';
+      });
+
+      const Wrapper = component(() => {
+        const result = fetchData(shouldFail.value);
+
+        if (result.isPending) return <div>Loading...</div>;
+        if (result.isRejected) return <div>error:{(result.error as Error).message}</div>;
+        return <div>ok:{result.value}</div>;
+      });
+
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { getByText } = render(<Wrapper />);
+
+      await expect.element(getByText('error:oops')).toBeInTheDocument();
+
+      // Fix the dep — the reactive should re-run and succeed
+      shouldFail.value = false;
+      await expect.element(getByText('ok:recovered')).toBeInTheDocument();
+
+      spy.mockRestore();
+    });
+  });
+
+  // =========================================================================
+  // Conditional await paths
+  // =========================================================================
+
+  describe('conditional await paths', () => {
+    test('component toggles between sync return and async await without getting stuck', async () => {
+      const useAsync = signal(true);
+
+      const AsyncComp = component(async () => {
+        const isAsync = useAsync.value;
+
+        if (isAsync) {
+          await sleep(50);
+          return <div>async-path</div>;
+        }
+
+        return <div>sync-path</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('async-path')).toBeInTheDocument();
+
+      // Switch to sync path
+      useAsync.value = false;
+      await expect.element(getByText('sync-path')).toBeInTheDocument();
+
+      // Switch back to async
+      useAsync.value = true;
+      await expect.element(getByText('async-path')).toBeInTheDocument();
+
+      // And back to sync again
+      useAsync.value = false;
+      await expect.element(getByText('sync-path')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Nested async components
+  // =========================================================================
+
+  describe('nested async components', () => {
+    test('parent and child async components resolve independently', async () => {
+      const parentInput = signal('P');
+      const childInput = signal('C');
+
+      const Child = component(async () => {
+        const v = childInput.value;
+        await sleep(50);
+        return <span>child:{v}</span>;
+      });
+
+      const Parent = component(async () => {
+        const v = parentInput.value;
+        await sleep(50);
+        return (
+          <div>
+            <span>parent:{v}</span>
+            <Suspense fallback={<span>child-loading</span>}>
+              <Child />
+            </Suspense>
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>parent-loading</div>}>
+          <Parent />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('parent-loading')).toBeInTheDocument();
+      await expect.element(getByText('parent:P')).toBeInTheDocument();
+      await expect.element(getByText('child:C')).toBeInTheDocument();
+
+      // Change only parent dep
+      parentInput.value = 'P2';
+      await expect.element(getByText('parent:P2')).toBeInTheDocument();
+      await expect.element(getByText('child:C')).toBeInTheDocument();
+
+      // Change only child dep
+      childInput.value = 'C2';
+      await expect.element(getByText('parent:P2')).toBeInTheDocument();
+      await expect.element(getByText('child:C2')).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Timing stress tests
+  // =========================================================================
+
+  describe('timing stress', () => {
+    test('alternating signal values do not cause infinite loop', async () => {
+      const toggle = signal(false);
+
+      let runCount = 0;
+
+      const AsyncComp = component(async () => {
+        runCount++;
+        const v = toggle.value;
+        await sleep(30);
+        return <div>toggle:{String(v)}</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('toggle:false')).toBeInTheDocument();
+
+      toggle.value = true;
+      await expect.element(getByText('toggle:true')).toBeInTheDocument();
+
+      toggle.value = false;
+      await expect.element(getByText('toggle:false')).toBeInTheDocument();
+
+      toggle.value = true;
+      await expect.element(getByText('toggle:true')).toBeInTheDocument();
+
+      expect(runCount).toBeLessThan(20);
+    });
+
+    test('very fast settle (microtask-level await) works', async () => {
+      const ext = signal('fast');
+
+      const AsyncComp = component(async () => {
+        const v = ext.value;
+        await Promise.resolve();
+        return <div>fast:{v}</div>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('fast:fast')).toBeInTheDocument();
+
+      ext.value = 'fast2';
+      await expect.element(getByText('fast:fast2')).toBeInTheDocument();
+    });
+
+    test('multiple sequential awaits within a single component', async () => {
+      const input = signal('a');
+
+      const step1 = reactive(async (key: string) => {
+        await sleep(30);
+        return `s1(${key})`;
+      });
+
+      const step2 = reactive(async (key: string) => {
+        await sleep(30);
+        return `s2(${key})`;
+      });
+
+      const AsyncComp = component(async () => {
+        const k = input.value;
+        const r1 = await step1(k);
+        const r2 = await step2(r1);
+        return (
+          <div>
+            chain:{r1}/{r2}
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <AsyncComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('chain:s1(a)/s2(s1(a))')).toBeInTheDocument();
+
+      input.value = 'b';
+      await expect.element(getByText('chain:s1(b)/s2(s1(b))')).toBeInTheDocument();
+    });
+
+    test('dependency invalidation during multi-step async resolution', async () => {
+      const userId = signal('alice');
+
+      const fetchUser = reactive(async (id: string) => {
+        await sleep(40);
+        return { id, name: id === 'alice' ? 'Alice' : 'Bob' };
+      });
+
+      const fetchPosts = reactive(async (userName: string) => {
+        await sleep(60);
+        return `${userName}'s posts`;
+      });
+
+      const Profile = component(async () => {
+        const user = await fetchUser(userId.value);
+        const posts = await fetchPosts(user.name);
+        return (
+          <div>
+            profile:{user.name}/{posts}
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <Profile />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+      await expect.element(getByText("profile:Alice/Alice's posts")).toBeInTheDocument();
+
+      // While the component is settled, change the userId.
+      // This invalidates fetchUser, which cascades to fetchPosts.
+      userId.value = 'bob';
+      await expect.element(getByText("profile:Bob/Bob's posts")).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Suspense boundary scenarios
+  // =========================================================================
+
+  describe('suspense boundary scenarios', () => {
+    test('multiple async siblings under one Suspense boundary', async () => {
+      const Fast = component(async () => {
+        await sleep(30);
+        return <span>fast-done</span>;
+      });
+
+      const Slow = component(async () => {
+        await sleep(100);
+        return <span>slow-done</span>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <Fast />
+          <Slow />
+        </Suspense>,
+      );
+
+      // Fallback stays until ALL siblings resolve
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+
+      // Both appear together once the slow one finishes
+      await expect.element(getByText('fast-done')).toBeInTheDocument();
+      await expect.element(getByText('slow-done')).toBeInTheDocument();
+    });
+
+    test('normal React Suspense component alongside async Signalium component', async () => {
+      // Standard React pattern: external cache + thrown promise
+      let resolveVanilla: (v: string) => void;
+      const vanillaPromise = new Promise<string>(r => {
+        resolveVanilla = r;
+      });
+      let vanillaResult: string | undefined;
+
+      const VanillaComp = () => {
+        if (vanillaResult === undefined) {
+          throw vanillaPromise;
+        }
+        return <span>vanilla:{vanillaResult}</span>;
+      };
+
+      vanillaPromise.then(v => {
+        vanillaResult = v;
+      });
+
+      const SignaliumComp = component(async () => {
+        await sleep(50);
+        return <span>signalium:done</span>;
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <VanillaComp />
+          <SignaliumComp />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+
+      // Resolve the vanilla promise after the Signalium one has had time to settle
+      await sleep(100);
+      resolveVanilla!('hello');
+
+      await expect.element(getByText('vanilla:hello')).toBeInTheDocument();
+      await expect.element(getByText('signalium:done')).toBeInTheDocument();
+    });
+
+    test('parent/child async components under same Suspense boundary (serial resolution)', async () => {
+      const parentInput = signal('P');
+      const childInput = signal('C');
+
+      const Child = component(async () => {
+        const v = childInput.value;
+        await sleep(50);
+        return <span>child:{v}</span>;
+      });
+
+      // Parent renders child directly — no inner Suspense boundary.
+      // The child suspends after the parent resolves, keeping the
+      // outer fallback visible until both have settled.
+      const Parent = component(async () => {
+        const v = parentInput.value;
+        await sleep(50);
+        return (
+          <div>
+            <span>parent:{v}</span>
+            <Child />
+          </div>
+        );
+      });
+
+      const { getByText } = render(
+        <Suspense fallback={<div>Loading...</div>}>
+          <Parent />
+        </Suspense>,
+      );
+
+      await expect.element(getByText('Loading...')).toBeInTheDocument();
+
+      // Both parent and child eventually render
+      await expect.element(getByText('parent:P')).toBeInTheDocument();
+      await expect.element(getByText('child:C')).toBeInTheDocument();
+
+      // Changes propagate through
+      parentInput.value = 'P2';
+      await expect.element(getByText('parent:P2')).toBeInTheDocument();
+
+      childInput.value = 'C2';
+      await expect.element(getByText('child:C2')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/signalium/src/react/component.tsx
+++ b/packages/signalium/src/react/component.tsx
@@ -1,45 +1,46 @@
-import { useMemo, useRef, useSyncExternalStore } from 'react';
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
 import { useScope } from './context.js';
 import { useSignalsSuspended } from './suspend-signals-context.js';
-import { createReactiveSignal, ReactiveSignal } from '../internals/reactive.js';
+import { ReactiveSignal, createReactiveDefinition } from '../internals/reactive.js';
 import { runSignal } from '../internals/get.js';
 import { hashValue } from '../internals/utils/hash.js';
+import { isReactivePromise, ReactivePromiseImpl } from '../internals/async.js';
+import { StateSignal } from '../internals/signal.js';
+import { getGlobalScope } from '../internals/contexts.js';
+
+type ComponentReturn = React.ReactNode | React.ReactNode[] | null;
+
+const GENERATOR_FN = function* () {}.constructor;
+
+const PROPS_MAP = new WeakMap<object, any>();
 
 export default function component<Props extends object>(
-  fn: (props: Props) => React.ReactNode | React.ReactNode[] | null,
+  fn: (props: Props) => ComponentReturn | Promise<ComponentReturn>,
 ) {
+  const isAsync = fn instanceof GENERATOR_FN;
+
+  const def = createReactiveDefinition<any, []>(
+    undefined,
+    undefined,
+    () => fn(PROPS_MAP.get(def)!),
+    () => false,
+    false,
+    undefined,
+    undefined,
+  );
+
   const Component = (props: Props) => {
-    const scope = useScope();
+    const scope = useScope() ?? getGlobalScope();
     const suspended = useSignalsSuspended();
 
-    const fnSignalRef = useRef<ReactiveSignal<React.ReactNode | React.ReactNode[] | null, []> | undefined>(undefined);
-    const propsRef = useRef<Props>(props);
+    PROPS_MAP.set(def, props);
 
-    propsRef.current = props;
-
-    let signal = fnSignalRef.current;
-
-    if (signal === undefined) {
-      fnSignalRef.current = signal = createReactiveSignal(
-        {
-          compute: () => fn(propsRef.current),
-          equals: () => false,
-          isRelay: false,
-          tracer: undefined,
-        },
-        [],
-        undefined,
-        scope,
-      );
-
-      signal._isLazy = true;
-    }
+    const signal = scope.get(def, []);
+    signal._isLazy = true;
 
     signal.setSuspended(suspended);
 
-    // We always want to re-render when the signal is updated, regardless of
-    // whether or not the result changed. This is because the signal is lazy,
-    // so it will not be updated until the next render.
     useSyncExternalStore(
       signal.addListenerLazy(),
       () => signal.updatedCount,
@@ -48,12 +49,37 @@ export default function component<Props extends object>(
 
     runSignal(signal as ReactiveSignal<any, any[]>);
 
-    return signal.value;
+    const result = signal.value;
+
+    if (isAsync && result !== null && typeof result === 'object' && isReactivePromise(result as object)) {
+      const promise = result as unknown as ReactivePromiseImpl<ComponentReturn>;
+      const version = promise['_version'] as StateSignal<number>;
+
+      // Subscribe to async value changes. Uses _updatedCount as snapshot
+      // (bumps only on value/error changes) to avoid re-render loops from
+      // pending→resolved flag transitions that don't change the value.
+      useSyncExternalStore(
+        useCallback((onStoreChange: () => void) => version.addListener(onStoreChange), [version]),
+        () => promise._updatedCount,
+        () => promise._updatedCount,
+      );
+
+      if (!promise.isReady) {
+        throw promise;
+      }
+
+      return promise.value as ComponentReturn;
+    }
+
+    return result as ComponentReturn;
   };
+
+  if (isAsync) {
+    return Component;
+  }
 
   return (props: Props) => {
     const hash = hashValue(props);
-    // Renders Comp only when hash changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return useMemo(() => <Component {...props} />, [hash]);
   };

--- a/packages/signalium/src/react/use-reactive.ts
+++ b/packages/signalium/src/react/use-reactive.ts
@@ -112,9 +112,9 @@ export function useReactiveDeep<R, Args extends readonly Narrowable[]>(fn: (...a
   const suspended = useSignalsSuspended();
 
   const scope = useScope() ?? getGlobalScope();
-  const signalRef = useRef<ReadonlySignal<R> | undefined>();
-  const cloneSignalRef = useRef<ReactiveSignal<R, any>>();
-  const valueRef = useRef<R>();
+  const signalRef = useRef<ReadonlySignal<R> | undefined>(undefined);
+  const cloneSignalRef = useRef<ReactiveSignal<R, any>>(undefined);
+  const valueRef = useRef<R>(undefined);
 
   const [, def] = getReactiveFnAndDefinition(fn as any);
 

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/component-async/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/component-async/after.ts
@@ -1,0 +1,12 @@
+import { component } from 'signalium/react';
+import { reactive, callback as _callback } from 'signalium';
+const fetchData = reactive(function* (id: string) {
+  const res = yield fetch(`/api/${id}`);
+  return res.json();
+});
+const MyComponent = component(function* (props: {
+  id: string;
+}) {
+  const data = yield fetchData(props.id);
+  return data;
+});

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/component-async/before.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/component-async/before.ts
@@ -1,0 +1,12 @@
+import { component } from 'signalium/react';
+import { reactive } from 'signalium';
+
+const fetchData = reactive(async (id: string) => {
+  const res = await fetch(`/api/${id}`);
+  return res.json();
+});
+
+const MyComponent = component(async (props: { id: string }) => {
+  const data = await fetchData(props.id);
+  return data;
+});

--- a/packages/signalium/src/transform/async.ts
+++ b/packages/signalium/src/transform/async.ts
@@ -10,6 +10,7 @@ function createSignaliumAsyncTransform(api: any, opts?: SignaliumAsyncTransformO
   const transformedImports = createTransformedImports(
     [
       ['callback', ['signalium']],
+      ['component', ['signalium/react']],
       ['reactive', ['signalium']],
       ['reactiveMethod', ['signalium']],
       ['relay', ['signalium']],


### PR DESCRIPTION
Enable `component(async () => {})` that integrates with React's <Suspense> boundaries. The async function is transformed to a generator by the Babel preset, allowing hooks to run in the synchronous portion before the first await while the reactive runtime manages the async lifecycle.

Key changes:

- Add `component` from `signalium/react` to the async Babel transform's tracked imports so async arrow/function expressions are rewritten to generators
- Refactor component() to use SignalScope for signal storage (survives React remounts during Suspense retry) and a WeakMap for props
- Detect async components via GeneratorFunction instanceof check; throw the ReactivePromise for Suspense when !isReady, subscribe to _updatedCount for value-change re-renders without pending/resolved flag transition loops
- Add AbortablePromise to generatorResultToPromiseWithConsumer so _setPromise can abort stale generators when replaced
- Add no-op `value` setter on ReactivePromiseImpl for React 19 compatibility (React 19's thenable tracking writes .value on thrown thenables)
- Update docs to document async components and remove the "components cannot be async" note
- 25 React tests covering Suspense basics, post-settle triggers (useSignal, signal, both simultaneously), mid-flight changes during initial Suspense, rapid re-triggers, mixed sync+async deps, error handling, conditional await paths, nested async components, and timing stress tests

Verified against both React 18.3.1 and React 19.2.4.