### PR TITLE
fix(signalium): handle abort errors without DOMException

### DIFF
--- a/.changeset/khg-hermes-abort-error.md
+++ b/.changeset/khg-hermes-abort-error.md
@@ -1,0 +1,5 @@
+---
+'signalium': patch
+---
+
+Handle AbortError values safely when DOMException is unavailable.

--- a/packages/signalium/src/__tests__/reactive-promise-methods.test.ts
+++ b/packages/signalium/src/__tests__/reactive-promise-methods.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { signal, ReactivePromise, Signal } from 'signalium';
 import { reactive } from './utils/instrumented-hooks.js';
 import { nextTick, sleep } from './utils/async.js';
+
+const originalDOMException = globalThis.DOMException;
+
+afterEach(() => {
+  if (originalDOMException === undefined) {
+    delete (globalThis as typeof globalThis & { DOMException?: typeof DOMException }).DOMException;
+  } else {
+    globalThis.DOMException = originalDOMException;
+  }
+});
 
 describe('Promise', () => {
   const createLoader = <T>(state: Signal<T>, delay = 5) =>
@@ -63,6 +73,20 @@ describe('Promise', () => {
       expect(rp.isRejected).toBe(true);
       expect(rp.error).toBe(err);
       await expect(Promise.resolve(rp)).rejects.toBe(err);
+    });
+
+    test('reject handles AbortError when DOMException is unavailable', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+
+      delete (globalThis as typeof globalThis & { DOMException?: typeof DOMException }).DOMException;
+
+      const rp = ReactivePromise.reject(abortError) as unknown as ReactivePromise<never>;
+      expect(rp.isRejected).toBe(true);
+      expect(rp.error).toBe(abortError);
+      await expect(Promise.resolve(rp)).rejects.toBe(abortError);
+      expect(consoleError).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/signalium/src/internals/async.ts
+++ b/packages/signalium/src/internals/async.ts
@@ -20,7 +20,11 @@ import { createCallback } from './callback.js';
 import { getTracerProxy, TracerEventType } from './trace.js';
 
 function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === 'AbortError';
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
+    return error.name === 'AbortError';
+  }
+
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 const enum AsyncFlags {


### PR DESCRIPTION
## Summary
Handle AbortError values safely when DOMException is unavailable.

## Changes
- guard the DOMException check in Signalium's abort detection
- fall back to Error objects with name "AbortError"
- add a regression test covering environments without DOMException
- add a changeset for a signalium patch release

## Related
- fetchium: https://github.com/Signalium/fetchium/pull/7

## Verification
- npm run check-types
- npm test -- --project unit src/__tests__/reactive-promise-methods.test.ts