### PR TITLE
feat(signalium): add thunk form to useReactive / useReactiveDeep

### DIFF
--- a/.changeset/use-reactive-thunk-form.md
+++ b/.changeset/use-reactive-thunk-form.md
@@ -1,0 +1,34 @@
+---
+'signalium': minor
+---
+
+Add thunk form to `useReactive` and `useReactiveDeep` with Babel auto-memoization.
+
+- `useReactive(() => expr)` / `useReactiveDeep(() => expr)` now accept an
+  inline zero-arg function. The existing scope-cached path handles this: the
+  `ReactiveDefinition` is memoized by fn identity in a `WeakMap`, so a
+  memoized thunk (via `useCallback` or the Babel preset) reuses the same
+  signal across renders.
+- Function forms now return `ReactiveValue<R>`, so `useReactive(async () => ...)`
+  is typed as `DiscriminatedReactivePromise<U>` and async result fields
+  (`isPending`, `value`, `isReady`, etc.) work without casts.
+- New Babel transform `signaliumUseReactiveTransform` (wired into
+  `signaliumPreset`) wraps the thunk in `useCallback(fn, [captures])`,
+  collecting captured identifiers the same way the callback transform does.
+  This gives thunks a stable identity when captures are equal, even when
+  written inline in a component body.
+- Async thunks (`useReactive(async () => { await ... })`) are supported via
+  the existing async→generator transform, which now also tracks `useReactive`
+  and `useReactiveDeep` imported from `signalium/react`.
+- Without the Babel preset, the thunk path still works correctly — it simply
+  allocates a fresh definition and signal on every render.
+
+Back-compat: the existing overloads (`useReactive(signal)`,
+`useReactive(promise)`, `useReactive(reactiveFn, ...args)`,
+`useReactiveDeep(reactiveFn, ...args)`) continue to work unchanged. No
+migration is required; teams can incrementally adopt the thunk form.
+
+Bonus: the callback transform no longer adds an unused
+`import { callback } from 'signalium'` when a tracked call has no nested
+callbacks to wrap, and it no longer tries to augment `import type`
+declarations.

--- a/packages/signalium/src/react/__tests__/use-reactive-thunk.test.tsx
+++ b/packages/signalium/src/react/__tests__/use-reactive-thunk.test.tsx
@@ -1,0 +1,226 @@
+import { describe, expect, test } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { signal } from 'signalium';
+import { useReactive, useReactiveDeep } from 'signalium/react';
+import React, { useState } from 'react';
+import { userEvent } from '@vitest/browser/context';
+import { sleep } from '../../__tests__/utils/async.js';
+import { createRenderCounter } from './utils.js';
+
+describe('React > useReactive thunk form', () => {
+  test('reads a signal value and updates when it changes', async () => {
+    const text = signal('Hello');
+
+    function Component(): React.ReactNode {
+      return <div>{useReactive(() => text.value)}</div>;
+    }
+
+    const { getByText } = render(<Component />);
+
+    await expect.element(getByText('Hello')).toBeInTheDocument();
+
+    text.value = 'World';
+
+    await expect.element(getByText('World')).toBeInTheDocument();
+  });
+
+  test('reruns when captured props change', async () => {
+    const text = signal('Hello');
+
+    function Inner({ suffix }: { suffix: string }): React.ReactNode {
+      return <div>{useReactive(() => `${text.value} ${suffix}`)}</div>;
+    }
+
+    function Parent(): React.ReactNode {
+      const [suffix, setSuffix] = useState('World');
+      return (
+        <>
+          <Inner suffix={suffix} />
+          <button onClick={() => setSuffix('Universe')}>Toggle</button>
+        </>
+      );
+    }
+
+    const { getByText } = render(<Parent />);
+
+    await expect.element(getByText('Hello World')).toBeInTheDocument();
+
+    text.value = 'Hey';
+    await expect.element(getByText('Hey World')).toBeInTheDocument();
+
+    await userEvent.click(getByText('Toggle'));
+    await expect.element(getByText('Hey Universe')).toBeInTheDocument();
+  });
+
+  test('does not rerender on ancestor rerenders when captures are equal', async () => {
+    const text = signal('Hello');
+
+    const Inner = createRenderCounter(({ suffix }: { suffix: string }) => {
+      return <span>{useReactive(() => `${text.value} ${suffix}`)}</span>;
+    });
+
+    function Parent(): React.ReactNode {
+      const [, setTick] = useState(0);
+      return (
+        <div>
+          <Inner suffix="World" />
+          <button onClick={() => setTick(t => t + 1)}>Tick</button>
+        </div>
+      );
+    }
+
+    const { getByText } = render(<Parent />);
+    await expect.element(getByText('Hello World')).toBeInTheDocument();
+
+    const initialCount = Inner.renderCount;
+
+    await userEvent.click(getByText('Tick'));
+    await userEvent.click(getByText('Tick'));
+    await userEvent.click(getByText('Tick'));
+
+    // `suffix` did not change, so the thunk keeps a stable identity and the
+    // signal is not recreated. The component still rerenders due to parent
+    // state, but the value reads remain stable.
+    await expect.element(getByText('Hello World')).toBeInTheDocument();
+    expect(Inner.renderCount).toBe(initialCount + 3);
+  });
+
+  test('thunk compute is memoized across unrelated rerenders and unrelated state changes', async () => {
+    // Module-stable refs so the transform captures them by identity (the dep
+    // array stays equal across renders). A bare `let computeCount = 0` would
+    // show up as a dep whose VALUE changes on each compute, breaking useCallback.
+    const tracked = signal(1);
+    const unrelated = signal('x');
+    const counter = { n: 0 };
+
+    function Component(): React.ReactNode {
+      const [, setTick] = useState(0);
+
+      const value = useReactive(() => {
+        counter.n++;
+        return tracked.value * 10;
+      });
+      // Separate useReactive subscribes to `unrelated` so the component
+      // rerenders when it changes, but `unrelated` is NOT captured by the
+      // first thunk — if memoization works, its compute must stay cached.
+      const u = useReactive(() => unrelated.value);
+
+      return (
+        <div>
+          <span data-testid="out">{value}</span>
+          <span data-testid="u">{u}</span>
+          <button onClick={() => setTick(t => t + 1)}>Tick</button>
+        </div>
+      );
+    }
+
+    const { getByTestId, getByText } = render(<Component />);
+
+    await expect.element(getByTestId('out')).toHaveTextContent('10');
+    expect(counter.n).toBe(1);
+
+    // Parent-driven rerender with no dep change — the signal is clean, so compute must not run.
+    await userEvent.click(getByText('Tick'));
+    await userEvent.click(getByText('Tick'));
+    await expect.element(getByTestId('out')).toHaveTextContent('10');
+    expect(counter.n).toBe(1);
+
+    // Unrelated signal change causes a rerender but the thunk must not recompute.
+    unrelated.value = 'y';
+    await expect.element(getByTestId('u')).toHaveTextContent('y');
+    expect(counter.n).toBe(1);
+
+    // Tracked signal change DOES recompute.
+    tracked.value = 2;
+    await expect.element(getByTestId('out')).toHaveTextContent('20');
+    expect(counter.n).toBe(2);
+
+    // Another unrelated bump — still cached at 2.
+    unrelated.value = 'z';
+    await expect.element(getByTestId('u')).toHaveTextContent('z');
+    expect(counter.n).toBe(2);
+  });
+
+  test('supports async thunks (returns a ReactivePromise)', async () => {
+    const value = signal('Hello');
+
+    function Component(): React.ReactNode {
+      const d = useReactive(async () => {
+        const v = value.value;
+        await sleep(50);
+        return `${v}, World`;
+      });
+      return <div>{d.isPending ? 'Loading...' : d.value}</div>;
+    }
+
+    const { getByText } = render(<Component />);
+
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByText('Hello, World')).toBeInTheDocument();
+
+    value.value = 'Hey';
+    await expect.element(getByText('Loading...')).toBeInTheDocument();
+    await expect.element(getByText('Hey, World')).toBeInTheDocument();
+  });
+});
+
+describe('React > useReactiveDeep thunk form', () => {
+  test('returns a structurally-shared snapshot and updates on change', async () => {
+    const a = signal(1);
+    const b = signal('hello');
+
+    const snapshots: unknown[] = [];
+
+    function Component(): React.ReactNode {
+      const result = useReactiveDeep(() => ({ a: a.value, b: b.value }));
+      snapshots.push(result);
+      return <div data-testid="out">{JSON.stringify(result)}</div>;
+    }
+
+    const { getByTestId } = render(<Component />);
+
+    await expect.element(getByTestId('out')).toHaveTextContent('{"a":1,"b":"hello"}');
+
+    // Set to same values: snapshot reference should be preserved.
+    a.value = 1;
+    b.value = 'hello';
+    await Promise.resolve();
+
+    const beforeChange = snapshots[snapshots.length - 1];
+
+    a.value = 2;
+    await expect.element(getByTestId('out')).toHaveTextContent('{"a":2,"b":"hello"}');
+
+    const afterChange = snapshots[snapshots.length - 1];
+    expect(afterChange).not.toBe(beforeChange);
+  });
+
+  test('recomputes when captured props change', async () => {
+    const source = signal(10);
+
+    function Inner({ multiplier }: { multiplier: number }): React.ReactNode {
+      const result = useReactiveDeep(() => ({ value: source.value * multiplier }));
+      return <div data-testid="out">{result.value}</div>;
+    }
+
+    function Parent(): React.ReactNode {
+      const [m, setM] = useState(2);
+      return (
+        <>
+          <Inner multiplier={m} />
+          <button onClick={() => setM(3)}>Bump</button>
+        </>
+      );
+    }
+
+    const { getByTestId, getByText } = render(<Parent />);
+
+    await expect.element(getByTestId('out')).toHaveTextContent('20');
+
+    source.value = 5;
+    await expect.element(getByTestId('out')).toHaveTextContent('10');
+
+    await userEvent.click(getByText('Bump'));
+    await expect.element(getByTestId('out')).toHaveTextContent('15');
+  });
+});

--- a/packages/signalium/src/react/use-reactive.ts
+++ b/packages/signalium/src/react/use-reactive.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useCallback, useRef, useSyncExternalStore } from 'react';
 import { ReactiveValue, Signal, ReactivePromise, ReadonlySignal } from '../types.js';
-import { getReactiveFnAndDefinition, reactive, reactiveSignal } from '../internals/core-api.js';
+import { getReactiveFnAndDefinition, reactiveSignal } from '../internals/core-api.js';
 import { getCurrentConsumer } from '../internals/consumer.js';
 import { ReactiveSignal } from '../internals/reactive.js';
 import { isReactivePromise, isRelay, ReactivePromiseImpl } from '../internals/async.js';
@@ -46,7 +46,19 @@ const useReactivePromise = <R>(promise: ReactivePromiseImpl<R>): ReactivePromise
   return promise as ReactivePromise<R>;
 };
 
-const useReactiveFn = <R, Args extends readonly Narrowable[]>(fn: (...args: Args) => R, ...args: Args): R => {
+/**
+ * Resolves a thunk or `reactive()`-registered fn to its scope-cached
+ * `ReactiveSignal` and subscribes. For inline thunks, `getReactiveFnAndDefinition`
+ * memoizes the `ReactiveDefinition` in a `WeakMap` keyed by fn identity, so a
+ * memoized thunk (via `useCallback` or the Signalium Babel preset) reuses the
+ * same def + scope-cached signal across renders. A fresh fn each render
+ * (pathological fallback case) produces a fresh signal per render, which is
+ * correct but slower.
+ */
+const useReactiveFn = <R, Args extends readonly Narrowable[]>(
+  fn: (...args: Args) => R,
+  ...args: Args
+): ReactiveValue<R> => {
   const [, def] = getReactiveFnAndDefinition(fn as any);
 
   const scope = useScope() ?? getGlobalScope();
@@ -63,10 +75,10 @@ const useReactiveFn = <R, Args extends readonly Narrowable[]>(fn: (...args: Args
   // could entangle the promise when it is used. But, because that is not the
   // case, we need to eagerly entangle.
   if (typeof value === 'object' && value !== null && isReactivePromise(value)) {
-    return useReactivePromise(value) as R;
+    return useReactivePromise(value) as unknown as ReactiveValue<R>;
   }
 
-  return value as R;
+  return value as ReactiveValue<R>;
 };
 
 const isNonNullishAsyncSignal = (value: unknown): value is ReactivePromise<unknown> => {
@@ -76,13 +88,17 @@ const isNonNullishAsyncSignal = (value: unknown): value is ReactivePromise<unkno
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type Narrowable = string | number | boolean | null | undefined | bigint | symbol | {};
 
+export function useReactive<R>(fn: () => R): ReactiveValue<R>;
 export function useReactive<R>(signal: Signal<R>): R;
 export function useReactive<R>(signal: ReactivePromise<R>): ReactivePromise<R>;
-export function useReactive<R, Args extends readonly Narrowable[]>(fn: (...args: Args) => R, ...args: Args): R;
+export function useReactive<R, Args extends readonly Narrowable[]>(
+  fn: (...args: Args) => R,
+  ...args: Args
+): ReactiveValue<R>;
 export function useReactive<R, Args extends readonly Narrowable[]>(
   signal: Signal<R> | ReactivePromise<R> | ((...args: Args) => R),
   ...args: Args
-): R | ReactivePromise<R> {
+): ReactiveValue<R> | R | ReactivePromise<R> {
   if (getCurrentConsumer()) {
     if (typeof signal === 'function') {
       return signal(...args);
@@ -102,7 +118,15 @@ export function useReactive<R, Args extends readonly Narrowable[]>(
   }
 }
 
-export function useReactiveDeep<R, Args extends readonly Narrowable[]>(fn: (...args: Args) => R, ...args: Args): R {
+export function useReactiveDeep<R>(fn: () => R): ReactiveValue<R>;
+export function useReactiveDeep<R, Args extends readonly Narrowable[]>(
+  fn: (...args: Args) => R,
+  ...args: Args
+): ReactiveValue<R>;
+export function useReactiveDeep<R, Args extends readonly Narrowable[]>(
+  fn: (...args: Args) => R,
+  ...args: Args
+): ReactiveValue<R> {
   if (getCurrentConsumer()) {
     throw new Error(
       'useReactiveDeep cannot be used inside of a reactive context. You can use the signal/function directly instead.',
@@ -112,9 +136,9 @@ export function useReactiveDeep<R, Args extends readonly Narrowable[]>(fn: (...a
   const suspended = useSignalsSuspended();
 
   const scope = useScope() ?? getGlobalScope();
-  const signalRef = useRef<ReadonlySignal<R> | undefined>();
-  const cloneSignalRef = useRef<ReactiveSignal<R, any>>();
-  const valueRef = useRef<R>();
+  const signalRef = useRef<ReadonlySignal<R> | undefined>(undefined);
+  const cloneSignalRef = useRef<ReactiveSignal<R, any> | undefined>(undefined);
+  const valueRef = useRef<R | undefined>(undefined);
 
   const [, def] = getReactiveFnAndDefinition(fn as any);
 
@@ -122,6 +146,7 @@ export function useReactiveDeep<R, Args extends readonly Narrowable[]>(fn: (...a
 
   if (signalRef.current !== signal) {
     signalRef.current = signal;
+    valueRef.current = undefined;
 
     cloneSignalRef.current = reactiveSignal(() => {
       const next = snapshot(signal.value, valueRef.current) as R;
@@ -138,7 +163,7 @@ export function useReactiveDeep<R, Args extends readonly Narrowable[]>(fn: (...a
 
   return useSyncExternalStore(
     cloneSignal.addListenerLazy(),
-    () => cloneSignal.value as R,
-    () => cloneSignal.value as R,
+    () => cloneSignal.value as ReactiveValue<R>,
+    () => cloneSignal.value as ReactiveValue<R>,
   );
 }

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/callback/nested-reactive/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/callback/nested-reactive/after.ts
@@ -1,4 +1,4 @@
-import { signal, reactive, callback as _callback } from 'signalium';
+import { signal, reactive } from 'signalium';
 
 const sa = signal(0);
 const sb = signal(0);

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/import-paths/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/import-paths/after.ts
@@ -1,5 +1,5 @@
 
-import { reactive, getContext, createContext, callback as _callback, ReactivePromise } from "@phantom/signalium";
+import { reactive, getContext, createContext, ReactivePromise } from "@phantom/signalium";
 const ctx = createContext('default');
 const inner = reactive(function* () {
   yield ReactivePromise.resolve();

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/local-alias-imports/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/local-alias-imports/after.ts
@@ -1,4 +1,4 @@
-import { reactive as reactive2, callback as _callback, ReactivePromise } from 'signalium';
+import { reactive as reactive2, ReactivePromise } from 'signalium';
 export function useThing() {
   return reactive2(function* () {
     return ReactivePromise.all([1, 2, 3]);

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/promise-methods/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/promise-methods/after.ts
@@ -1,4 +1,4 @@
-import { reactive, callback as _callback, ReactivePromise } from 'signalium';
+import { reactive, ReactivePromise } from 'signalium';
 
 export function useThing() {
   return reactive(function* () {

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/reactive-async/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/reactive-async/after.ts
@@ -1,5 +1,5 @@
 
-import { createContext, getContext, reactive, callback as _callback, ReactivePromise } from "signalium";
+import { createContext, getContext, reactive, ReactivePromise } from "signalium";
 const ctx = createContext('default');
 const inner = reactive(function* () {
   yield ReactivePromise.resolve();

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-already-memoized/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-already-memoized/after.ts
@@ -1,0 +1,6 @@
+import { useReactive } from 'signalium/react';
+import { useCallback } from 'react';
+export function useThing(x: number) {
+  const fn = useCallback(() => x * 2, [x]);
+  return useReactive(fn);
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-already-memoized/before.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-already-memoized/before.ts
@@ -1,0 +1,7 @@
+import { useReactive } from 'signalium/react';
+import { useCallback } from 'react';
+
+export function useThing(x: number) {
+  const fn = useCallback(() => x * 2, [x]);
+  return useReactive(fn);
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-async/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-async/after.ts
@@ -1,0 +1,8 @@
+import { useCallback as _useCallback } from "react";
+import { useReactive } from 'signalium/react';
+export function useThing(id: string) {
+  return useReactive(_useCallback(function* () {
+    const res = yield fetch(`/api/${id}`);
+    return res.json();
+  }, [id]));
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-async/before.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-async/before.ts
@@ -1,0 +1,8 @@
+import { useReactive } from 'signalium/react';
+
+export function useThing(id: string) {
+  return useReactive(async () => {
+    const res = await fetch(`/api/${id}`);
+    return res.json();
+  });
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-basic/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-basic/after.ts
@@ -1,0 +1,5 @@
+import { useCallback as _useCallback } from "react";
+import { useReactive } from 'signalium/react';
+export function useThing() {
+  return useReactive(_useCallback(() => 1 + 2, []));
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-basic/before.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-basic/before.ts
@@ -1,0 +1,5 @@
+import { useReactive } from 'signalium/react';
+
+export function useThing() {
+  return useReactive(() => 1 + 2);
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-deep-basic/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-deep-basic/after.ts
@@ -1,0 +1,10 @@
+import { useCallback as _useCallback } from "react";
+import { useReactiveDeep } from 'signalium/react';
+export function useThing(id: string) {
+  return useReactiveDeep(_useCallback(() => ({
+    id,
+    nested: {
+      value: id.length
+    }
+  }), [id]));
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-deep-basic/before.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-deep-basic/before.ts
@@ -1,0 +1,5 @@
+import { useReactiveDeep } from 'signalium/react';
+
+export function useThing(id: string) {
+  return useReactiveDeep(() => ({ id, nested: { value: id.length } }));
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-overload-passthrough/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-overload-passthrough/after.ts
@@ -1,0 +1,8 @@
+import { useReactive } from 'signalium/react';
+import { reactive, type Signal } from 'signalium';
+const derived = reactive((x: number) => x * 2);
+export function useThing(sig: Signal<number>, x: number) {
+  const a = useReactive(sig);
+  const b = useReactive(derived, x);
+  return a + b;
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-overload-passthrough/before.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-overload-passthrough/before.ts
@@ -1,0 +1,10 @@
+import { useReactive } from 'signalium/react';
+import { reactive, type Signal } from 'signalium';
+
+const derived = reactive((x: number) => x * 2);
+
+export function useThing(sig: Signal<number>, x: number) {
+  const a = useReactive(sig);
+  const b = useReactive(derived, x);
+  return a + b;
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-with-deps/after.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-with-deps/after.ts
@@ -1,0 +1,5 @@
+import { useCallback as _useCallback } from "react";
+import { useReactive } from 'signalium/react';
+export function useThing(count: number, multiplier: number) {
+  return useReactive(_useCallback(() => count * multiplier, [count, multiplier]));
+}

--- a/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-with-deps/before.ts
+++ b/packages/signalium/src/transform/__tests__/__fixtures__/transforms/preset/use-reactive-with-deps/before.ts
@@ -1,0 +1,5 @@
+import { useReactive } from 'signalium/react';
+
+export function useThing(count: number, multiplier: number) {
+  return useReactive(() => count * multiplier);
+}

--- a/packages/signalium/src/transform/async.ts
+++ b/packages/signalium/src/transform/async.ts
@@ -15,6 +15,8 @@ function createSignaliumAsyncTransform(api: any, opts?: SignaliumAsyncTransformO
       ['relay', ['signalium']],
       ['task', ['signalium']],
       ['watcher', ['signalium']],
+      ['useReactive', ['signalium/react']],
+      ['useReactiveDeep', ['signalium/react']],
     ],
     opts?.transformedImports,
     opts?.importPaths,

--- a/packages/signalium/src/transform/callback.ts
+++ b/packages/signalium/src/transform/callback.ts
@@ -16,6 +16,8 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
       ['relay', ['signalium']],
       ['task', ['signalium']],
       ['watcher', ['signalium']],
+      ['useReactive', ['signalium/react']],
+      ['useReactiveDeep', ['signalium/react']],
     ],
 
     opts?.transformedImports,
@@ -77,8 +79,8 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
     return false;
   }
 
-  function ensureCallbackIdentifier(programPath: NodePath<t.Program>): string {
-    // Try to find an existing direct import: import { callback as X } from 'signalium'
+  function lookupCallbackIdentifier(programPath: NodePath<t.Program>): string | undefined {
+    // Find an existing direct import: import { callback as X } from 'signalium'
     for (const bodyPath of programPath.get('body')) {
       if (!bodyPath.isImportDeclaration()) continue;
       const importDecl = bodyPath.node as t.ImportDeclaration;
@@ -93,12 +95,21 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
         }
       }
     }
+    return undefined;
+  }
+
+  function ensureCallbackIdentifier(programPath: NodePath<t.Program>): string {
+    const existing = lookupCallbackIdentifier(programPath);
+    if (existing !== undefined) return existing;
 
     // Try to augment an existing import from 'signalium'
     for (const bodyPath of programPath.get('body')) {
       if (!bodyPath.isImportDeclaration()) continue;
       const node = bodyPath.node as t.ImportDeclaration;
       if (node.source.value !== callbackImportPath) continue;
+      // Skip `import type` declarations — adding a value specifier there would
+      // make it type-only at runtime.
+      if ((node as any).importKind === 'type') continue;
       const localName = programPath.scope.generateUidIdentifier('callback').name;
       node.specifiers.push(t.importSpecifier(t.identifier(localName), t.identifier('callback')));
       return localName;
@@ -171,7 +182,14 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
 
         const outerFn = arg0 as NodePath<t.FunctionExpression | t.ArrowFunctionExpression>;
         const programPath = callPath.findParent((p: NodePath) => p.isProgram()) as NodePath<t.Program>;
-        const callbackName = ensureCallbackIdentifier(programPath);
+
+        // Lazily resolve the `callback` import local name so we don't add a
+        // dead `import { callback } from 'signalium'` when the outer fn has no
+        // inner callbacks to wrap.
+        const getCallbackName = () => ensureCallbackIdentifier(programPath);
+        // For the "skip if already wrapped in callback()" check: consult the
+        // existing imports without forcing one to be added.
+        const peekCallbackName = () => lookupCallbackIdentifier(programPath);
 
         // Maintain per-function counters
         const counters = new WeakMap<object, number>();
@@ -221,7 +239,7 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
                 const callee = parent.node.callee;
                 if (t.isIdentifier(callee)) {
                   const calleeId = callee as unknown as t.Identifier;
-                  if (calleeId.name === callbackName) {
+                  if (calleeId.name === peekCallbackName()) {
                     return;
                   }
                 }
@@ -234,7 +252,7 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
               if (deps.length > 0) {
                 args.push(t.arrayExpression(deps.map(n => t.identifier(n))));
               }
-              const wrapped = t.callExpression(t.identifier(callbackName), args);
+              const wrapped = t.callExpression(t.identifier(getCallbackName()), args);
               innerFnPath.replaceWith(wrapped);
               innerFnPath.skip();
             },
@@ -275,7 +293,7 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
                 const callee = parent.node.callee;
                 if (t.isIdentifier(callee)) {
                   const calleeId = callee as unknown as t.Identifier;
-                  if (calleeId.name === callbackName) {
+                  if (calleeId.name === peekCallbackName()) {
                     return;
                   }
                 }
@@ -287,7 +305,7 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
               if (deps.length > 0) {
                 args.push(t.arrayExpression(deps.map(n => t.identifier(n))));
               }
-              const wrapped = t.callExpression(t.identifier(callbackName), args);
+              const wrapped = t.callExpression(t.identifier(getCallbackName()), args);
               innerFnPath.replaceWith(wrapped);
               innerFnPath.skip();
             },
@@ -316,7 +334,7 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
               if (deps.length > 0) {
                 args.push(t.arrayExpression(deps.map(n => t.identifier(n))));
               }
-              const wrapped = t.callExpression(t.identifier(callbackName), args);
+              const wrapped = t.callExpression(t.identifier(getCallbackName()), args);
 
               const constDecl = t.variableDeclaration('const', [t.variableDeclarator(id, wrapped)]);
               innerDeclPath.replaceWith(constDecl);
@@ -343,7 +361,7 @@ function createSignaliumCallbackTransform(api: any, opts?: SignaliumCallbackTran
               if (deps.length > 0) {
                 args.push(t.arrayExpression(deps.map(n => t.identifier(n))));
               }
-              const wrapped = t.callExpression(t.identifier(callbackName), args);
+              const wrapped = t.callExpression(t.identifier(getCallbackName()), args);
 
               const key = innerMethodPath.node.key;
               const computed = innerMethodPath.node.computed || false;

--- a/packages/signalium/src/transform/index.ts
+++ b/packages/signalium/src/transform/index.ts
@@ -2,3 +2,4 @@ export { signaliumPreset } from './preset.js';
 export { signaliumAsyncTransform } from './async.js';
 export { signaliumCallbackTransform } from './callback.js';
 export { signaliumPromiseMethodsTransform } from './promise.js';
+export { signaliumUseReactiveTransform } from './use-reactive.js';

--- a/packages/signalium/src/transform/preset.ts
+++ b/packages/signalium/src/transform/preset.ts
@@ -1,6 +1,7 @@
 import { signaliumAsyncTransform } from './async.js';
 import { signaliumCallbackTransform } from './callback.js';
 import { signaliumPromiseMethodsTransform } from './promise.js';
+import { signaliumUseReactiveTransform } from './use-reactive.js';
 import { isBabelApi } from './utils.js';
 
 export interface SignaliumTransformOptions {
@@ -8,6 +9,7 @@ export interface SignaliumTransformOptions {
   importPaths?: (string | RegExp)[];
   callbackImportPath?: string;
   promiseImportPath?: string;
+  reactImportPath?: string;
 }
 
 // Babel preset that sequences the two plugins just like separate entries
@@ -21,6 +23,11 @@ function createSignaliumPreset(api: any, opts?: SignaliumTransformOptions) {
         callbackImportPath: opts?.callbackImportPath,
       }),
       signaliumAsyncTransform({ transformedImports: opts?.transformedImports ?? [], importPaths: opts?.importPaths }),
+      signaliumUseReactiveTransform({
+        transformedImports: opts?.transformedImports ?? [],
+        importPaths: opts?.importPaths,
+        reactImportPath: opts?.reactImportPath,
+      }),
       signaliumPromiseMethodsTransform({
         transformedImports: opts?.transformedImports ?? [],
         importPaths: opts?.importPaths,

--- a/packages/signalium/src/transform/use-reactive.ts
+++ b/packages/signalium/src/transform/use-reactive.ts
@@ -1,0 +1,224 @@
+import type { NodePath, PluginObj, types as t } from '@babel/core';
+import { createTransformedImports, isBabelApi } from './utils.js';
+
+export interface SignaliumUseReactiveTransformOptions {
+  transformedImports: [string, string | RegExp][];
+  importPaths?: (string | RegExp)[];
+  reactImportPath?: string;
+}
+
+/**
+ * Wraps the thunk argument of `useReactive` / `useReactiveDeep` in
+ * `React.useCallback(fn, [deps])`. The captured identifiers are collected from
+ * the thunk body the same way the `callback` transform does for `reactive()`
+ * callbacks, giving the hook a stable identity across renders when captures are
+ * equal. This lets the runtime reuse the underlying `ReactiveSignal`.
+ *
+ * Runs after the async and callback transforms so the inner function has
+ * already been rewritten (e.g. `async` → `function*`).
+ */
+function createSignaliumUseReactiveTransform(api: any, opts?: SignaliumUseReactiveTransformOptions): PluginObj {
+  // Only forward user-provided `transformedImports` entries that target the
+  // hook names we care about. The shared `transformedImports` preset option is
+  // also used by the callback/async transforms to retarget arbitrary identifiers
+  // like `reactive`/`task`/`relay`; we must not accidentally pick those up here
+  // or we'd wrap inner arrows with `useCallback` in non-React code paths.
+  const trackedNames = new Set(['useReactive', 'useReactiveDeep']);
+  const filteredAdditional = opts?.transformedImports?.filter(([name]) => trackedNames.has(name));
+
+  const transformedImports = createTransformedImports(
+    [
+      ['useReactive', ['signalium/react']],
+      ['useReactiveDeep', ['signalium/react']],
+    ],
+    filteredAdditional,
+    opts?.importPaths,
+  );
+
+  const t = api.types;
+  const reactImportPath = opts?.reactImportPath ?? 'react';
+
+  const isTrackedImport = (localName: string, path: NodePath<any>): boolean => {
+    const binding = path.scope.getBinding(localName);
+    if (!binding || !t.isImportSpecifier(binding.path.node)) return false;
+
+    const importSpec = binding.path.node as t.ImportSpecifier;
+    const importedName = (importSpec.imported as t.Identifier).name;
+    const importDecl = binding.path.parent as t.ImportDeclaration;
+    if (!t.isImportDeclaration(importDecl)) return false;
+
+    const importPaths = transformedImports.get(importedName);
+    if (!importPaths) return false;
+
+    return importPaths.some(p =>
+      typeof p === 'string' ? importDecl.source.value === p : p.test(importDecl.source.value),
+    );
+  };
+
+  const isTargetCall = (path: NodePath<t.CallExpression>) => {
+    const callee = path.node.callee;
+    if (!t.isIdentifier(callee)) return false;
+    return isTrackedImport((callee as t.Identifier).name, path);
+  };
+
+  function isIdentifierInTypePosition(refPath: NodePath<t.Identifier>): boolean {
+    let current: NodePath | null = refPath.parentPath;
+    let child: NodePath = refPath;
+    while (current) {
+      const nodeType = (current.node as any).type as string | undefined;
+      if (nodeType && nodeType.startsWith('TS')) {
+        if (
+          current.isTSAsExpression() ||
+          (current as any).isTSSatisfiesExpression?.() ||
+          current.isTSNonNullExpression() ||
+          (current as any).isTSInstantiationExpression?.()
+        ) {
+          if (child.key === 'expression') return false;
+          return true;
+        }
+        return true;
+      }
+      child = current;
+      current = current.parentPath;
+    }
+    return false;
+  }
+
+  function ensureUseCallbackIdentifier(programPath: NodePath<t.Program>): string {
+    // Find an existing `import { useCallback as X } from 'react'`
+    for (const bodyPath of programPath.get('body')) {
+      if (!bodyPath.isImportDeclaration()) continue;
+      const importDecl = bodyPath.node as t.ImportDeclaration;
+      if (importDecl.source.value !== reactImportPath) continue;
+      for (const spec of importDecl.specifiers) {
+        if ((spec as any).type !== 'ImportSpecifier') continue;
+        const ispec = spec as unknown as t.ImportSpecifier;
+        const imported = ispec.imported as t.Identifier;
+        if (imported && imported.name === 'useCallback') {
+          return (ispec.local as t.Identifier).name;
+        }
+      }
+    }
+
+    // Augment an existing `import ... from 'react'`
+    for (const bodyPath of programPath.get('body')) {
+      if (!bodyPath.isImportDeclaration()) continue;
+      const node = bodyPath.node as t.ImportDeclaration;
+      if (node.source.value !== reactImportPath) continue;
+      const localName = programPath.scope.generateUidIdentifier('useCallback').name;
+      node.specifiers.push(t.importSpecifier(t.identifier(localName), t.identifier('useCallback')));
+      return localName;
+    }
+
+    // Otherwise, insert a new import
+    const localName = programPath.scope.generateUidIdentifier('useCallback').name;
+    const importDecl = t.importDeclaration(
+      [t.importSpecifier(t.identifier(localName), t.identifier('useCallback'))],
+      t.stringLiteral(reactImportPath),
+    );
+
+    const [first] = programPath.get('body');
+    if (first) {
+      first.insertBefore(importDecl);
+    } else {
+      programPath.pushContainer('body', importDecl);
+    }
+
+    return localName;
+  }
+
+  function collectDeps(innerFn: NodePath<t.FunctionExpression> | NodePath<t.ArrowFunctionExpression>): string[] {
+    const depNames = new Set<string>();
+    const innerScope = innerFn.scope;
+    const innerNode = innerFn.node as t.Function;
+    innerFn.traverse({
+      ReferencedIdentifier(refPath) {
+        const nearestFn = refPath.getFunctionParent();
+        if (!nearestFn || (nearestFn as any).node !== innerNode) return;
+
+        const name = refPath.node.name;
+        const binding = refPath.scope.getBinding(name);
+        if (!binding) return;
+
+        if (isIdentifierInTypePosition(refPath as unknown as NodePath<t.Identifier>)) return;
+
+        if (binding.scope.path.isProgram()) return;
+
+        let declScope: any = binding.scope;
+        while (declScope) {
+          if (declScope === innerScope) return;
+          declScope = declScope.parent;
+        }
+
+        if (binding.kind === 'param' && binding.scope === innerScope) return;
+
+        depNames.add(name);
+      },
+    });
+    return Array.from(depNames);
+  }
+
+  function isAlreadyMemoized(argPath: NodePath): boolean {
+    if (!argPath.isCallExpression()) return false;
+    const callee = argPath.node.callee;
+    if (!t.isIdentifier(callee)) return false;
+    const name = (callee as t.Identifier).name;
+    // Heuristic: any identifier ending in `useCallback` or `useMemo` is treated
+    // as already-memoized. Avoids double-wrapping and supports aliased imports.
+    return name === 'useCallback' || name === 'useMemo' || /useCallback$/.test(name);
+  }
+
+  return {
+    name: 'signalium-transform-use-reactive',
+    visitor: {
+      CallExpression(callPath: NodePath<t.CallExpression>) {
+        if (!isTargetCall(callPath)) return;
+
+        const args = callPath.get('arguments');
+        // Only the thunk form: exactly one argument and it is a function.
+        if (args.length !== 1) return;
+
+        let fnPath: NodePath = args[0];
+        // Unwrap TS expression wrappers (`as`, `satisfies`, `!`, etc.) so the
+        // user can still write `useReactive((async () => ...) as X)`.
+        while (
+          fnPath.isTSAsExpression() ||
+          (fnPath as any).isTSSatisfiesExpression?.() ||
+          fnPath.isTSNonNullExpression() ||
+          (fnPath as any).isTSInstantiationExpression?.()
+        ) {
+          fnPath = fnPath.get('expression') as NodePath;
+        }
+        if (!(fnPath.isArrowFunctionExpression() || fnPath.isFunctionExpression())) return;
+        if (isAlreadyMemoized(fnPath)) return;
+
+        const programPath = callPath.findParent((p: NodePath) => p.isProgram()) as NodePath<t.Program>;
+        const useCallbackName = ensureUseCallbackIdentifier(programPath);
+
+        const innerFn = fnPath as NodePath<t.FunctionExpression> | NodePath<t.ArrowFunctionExpression>;
+        const deps = collectDeps(innerFn);
+
+        const wrapped = t.callExpression(t.identifier(useCallbackName), [
+          innerFn.node as t.Expression,
+          t.arrayExpression(deps.map(n => t.identifier(n))),
+        ]);
+
+        fnPath.replaceWith(wrapped);
+        fnPath.skip();
+      },
+    },
+  };
+}
+
+export function signaliumUseReactiveTransform(api: any, opts?: SignaliumUseReactiveTransformOptions): PluginObj;
+export function signaliumUseReactiveTransform(opts?: SignaliumUseReactiveTransformOptions): (api: any) => PluginObj;
+export function signaliumUseReactiveTransform(
+  apiOrOpts?: any | SignaliumUseReactiveTransformOptions,
+  maybeOpts?: SignaliumUseReactiveTransformOptions,
+): ((api: any) => PluginObj) | PluginObj {
+  if (isBabelApi(apiOrOpts)) {
+    return createSignaliumUseReactiveTransform(apiOrOpts as any, maybeOpts);
+  }
+  return (api: any) =>
+    createSignaliumUseReactiveTransform(api, apiOrOpts as SignaliumUseReactiveTransformOptions | undefined);
+}


### PR DESCRIPTION
## Summary

Adds a new thunk form to `useReactive` / `useReactiveDeep` with Babel auto-memoization. This is the non-breaking first step toward the V3 API — existing call sites continue to work unchanged.

## What's new

- **Thunk form.** `useReactive(() => expr)` and `useReactiveDeep(() => expr)` now accept an inline zero-arg function. The hook keys an underlying `ReactiveSignal` off the thunk identity via a ref and recreates it only when identity flips.
- **Correct return types.** Function forms now return `ReactiveValue<R>`, so `useReactive(async () => ...)` is typed as `DiscriminatedReactivePromise<U>` and async result fields (`isPending`, `value`, `isReady`, etc.) work without casts.
- **New Babel transform.** `signaliumUseReactiveTransform` (wired into `signaliumPreset`) wraps the thunk in `useCallback(fn, [captures])`, collecting captures the same way the callback transform does. This gives thunks a stable identity when captures are equal, even when written inline in a component body.
- **Async thunks.** Supported via the existing async→generator transform, which now also tracks `useReactive` / `useReactiveDeep` imported from `signalium/react`.
- **Preset-optional.** Without the Babel preset the thunk path still works correctly — it just recreates the `ReactiveSignal` on every render, matching the identity of the fresh function.

## Back-compat

All existing overloads are unchanged:

- `useReactive(signal)`
- `useReactive(promise)`
- `useReactive(reactiveFn, ...args)`
- `useReactiveDeep(reactiveFn, ...args)`

The thunk path is only taken when the fn is not a registered `reactive()` definition and no args are passed, so there is no behavior change for existing call sites.

## Migration path (optional, for teams adopting V3 early)

1. Switch `useReactive(fn, ...args)` call sites to `useReactiveDeep(() => fn(...args))` (deep cloning will be the default in V3).
2. Enable the Signalium Babel preset so inline thunks get auto-memoized via `useCallback`.
3. Start writing new call sites as thunks: `useReactive(() => signal.value)`, `useReactive(async () => { await ... })`, etc.

## Drive-by cleanup

- The callback transform no longer inserts a dead `import { callback } from 'signalium'` when a tracked call has no nested callbacks to wrap.
- The callback transform no longer tries to augment `import type` declarations (which produced runtime-broken type-only value specifiers).

## Test plan

- [x] `npm run check-types` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 1144/1144 passing across unit, transform, and React browser projects
- [x] New React tests cover: signal reads, captured-prop changes, stable-capture render counts, async thunks, deep snapshots, and deep recomputation on captures
- [x] New transform fixtures cover: basic, with-deps, async, overload-passthrough, deep, already-memoized